### PR TITLE
Hide observation API from public API on template and listener

### DIFF
--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAnnotationDrivenConfiguration.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAnnotationDrivenConfiguration.java
@@ -67,7 +67,7 @@ public class PulsarAnnotationDrivenConfiguration {
 		containerProperties.setSchemaResolver(schemaResolver);
 		containerProperties.setTopicResolver(topicResolver);
 		containerProperties.setSubscriptionType(this.pulsarProperties.getConsumer().getSubscriptionType());
-		containerProperties.setObservationConvention(observationConventionProvider.getIfUnique());
+		containerProperties.setObservationEnabled(this.pulsarProperties.getListener().isObservationsEnabled());
 
 		PropertyMapper map = PropertyMapper.get().alwaysApplyingWhenNonNull();
 		PulsarProperties.Listener listenerProperties = this.pulsarProperties.getListener();
@@ -79,8 +79,7 @@ public class PulsarAnnotationDrivenConfiguration {
 		map.from(listenerProperties::getMaxNumMessages).to(containerProperties::setMaxNumMessages);
 
 		return new ConcurrentPulsarListenerContainerFactory<>(consumerFactoryProvider.getIfAvailable(),
-				containerProperties, this.pulsarProperties.getListener().isObservationsEnabled()
-						? observationRegistryProvider.getIfUnique() : null);
+				containerProperties);
 	}
 
 	@Bean

--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
@@ -49,9 +49,6 @@ import org.springframework.pulsar.function.PulsarFunction;
 import org.springframework.pulsar.function.PulsarFunctionAdministration;
 import org.springframework.pulsar.function.PulsarSink;
 import org.springframework.pulsar.function.PulsarSource;
-import org.springframework.pulsar.observation.PulsarTemplateObservationConvention;
-
-import io.micrometer.observation.ObservationRegistry;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Apache Pulsar.
@@ -101,12 +98,9 @@ public class PulsarAutoConfiguration {
 	@ConditionalOnMissingBean
 	public PulsarTemplate<?> pulsarTemplate(PulsarProducerFactory<?> pulsarProducerFactory,
 			ObjectProvider<ProducerInterceptor> interceptorsProvider, SchemaResolver schemaResolver,
-			TopicResolver topicResolver, ObjectProvider<ObservationRegistry> observationRegistryProvider,
-			ObjectProvider<PulsarTemplateObservationConvention> observationConventionProvider) {
+			TopicResolver topicResolver) {
 		return new PulsarTemplate<>(pulsarProducerFactory, interceptorsProvider.orderedStream().toList(),
-				schemaResolver, topicResolver, this.properties.getTemplate().isObservationsEnabled()
-						? observationRegistryProvider.getIfUnique() : null,
-				observationConventionProvider.getIfUnique());
+				schemaResolver, topicResolver, this.properties.getTemplate().isObservationsEnabled());
 	}
 
 	@Bean

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfigurationTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfigurationTests.java
@@ -65,11 +65,8 @@ import org.springframework.pulsar.core.TopicResolver;
 import org.springframework.pulsar.function.PulsarFunctionAdministration;
 import org.springframework.pulsar.listener.AckMode;
 import org.springframework.pulsar.listener.PulsarContainerProperties;
-import org.springframework.pulsar.observation.PulsarListenerObservationConvention;
-import org.springframework.pulsar.observation.PulsarTemplateObservationConvention;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
-import io.micrometer.observation.ObservationRegistry;
 
 /**
  * Autoconfiguration tests for {@link PulsarAutoConfiguration}.
@@ -420,61 +417,42 @@ class PulsarAutoConfigurationTests {
 
 		@Test
 		void templateObservationsEnabledByDefault() {
-			ObservationRegistry observationRegistry = mock(ObservationRegistry.class);
-			contextRunner.withBean("observationRegistry", ObservationRegistry.class, () -> observationRegistry)
-					.run((context -> assertThat(context).hasNotFailed().getBean(PulsarTemplate.class)
-							.extracting("observationRegistry").isSameAs(observationRegistry)));
+			contextRunner.run((context -> assertThat(context).getBean(PulsarTemplate.class)
+					.hasFieldOrPropertyWithValue("observationEnabled", true)));
+		}
+
+		@Test
+		void templateObservationsEnabledExplicitly() {
+			contextRunner.withPropertyValues("spring.pulsar.template.observations-enabled=true")
+					.run((context -> assertThat(context).getBean(PulsarTemplate.class)
+							.hasFieldOrPropertyWithValue("observationEnabled", true)));
 		}
 
 		@Test
 		void templateObservationsCanBeDisabled() {
-			ObservationRegistry observationRegistry = mock(ObservationRegistry.class);
 			contextRunner.withPropertyValues("spring.pulsar.template.observations-enabled=false")
-					.withBean("observationRegistry", ObservationRegistry.class, () -> observationRegistry)
-					.run((context -> assertThat(context).hasNotFailed().getBean(PulsarTemplate.class)
-							.extracting("observationRegistry").isNull()));
-		}
-
-		@Test
-		void templateObservationsWithCustomConvention() {
-			ObservationRegistry observationRegistry = mock(ObservationRegistry.class);
-			PulsarTemplateObservationConvention customConvention = mock(PulsarTemplateObservationConvention.class);
-			contextRunner.withBean("observationRegistry", ObservationRegistry.class, () -> observationRegistry)
-					.withBean("customConvention", PulsarTemplateObservationConvention.class, () -> customConvention)
-					.run((context -> assertThat(context).hasNotFailed().getBean(PulsarTemplate.class)
-							.extracting("observationConvention").isSameAs(customConvention)));
+					.run((context -> assertThat(context).getBean(PulsarTemplate.class)
+							.hasFieldOrPropertyWithValue("observationEnabled", false)));
 		}
 
 		@Test
 		void listenerObservationsEnabledByDefault() {
-			ObservationRegistry observationRegistry = mock(ObservationRegistry.class);
-			contextRunner.withBean("observationRegistry", ObservationRegistry.class, () -> observationRegistry)
-					.run((context -> assertThat(context).hasNotFailed()
-							.getBean(ConcurrentPulsarListenerContainerFactory.class).extracting("observationRegistry")
-							.isSameAs(observationRegistry)));
+			contextRunner.run((context -> assertThat(context).getBean(ConcurrentPulsarListenerContainerFactory.class)
+					.hasFieldOrPropertyWithValue("containerProperties.observationEnabled", true)));
+		}
+
+		@Test
+		void listenerObservationsEnabledExplicitly() {
+			contextRunner.withPropertyValues("spring.pulsar.listener.observations-enabled=true")
+					.run((context -> assertThat(context).getBean(ConcurrentPulsarListenerContainerFactory.class)
+							.hasFieldOrPropertyWithValue("containerProperties.observationEnabled", true)));
 		}
 
 		@Test
 		void listenerObservationsCanBeDisabled() {
-			ObservationRegistry observationRegistry = mock(ObservationRegistry.class);
 			contextRunner.withPropertyValues("spring.pulsar.listener.observations-enabled=false")
-					.withBean("observationRegistry", ObservationRegistry.class, () -> observationRegistry)
-					.run((context -> assertThat(context).hasNotFailed()
-							.getBean(ConcurrentPulsarListenerContainerFactory.class).extracting("observationRegistry")
-							.isNull()));
-		}
-
-		@Test
-		void listenerObservationsWithCustomConvention() {
-			ObservationRegistry observationRegistry = mock(ObservationRegistry.class);
-			PulsarListenerObservationConvention customConvention = mock(PulsarListenerObservationConvention.class);
-			contextRunner.withBean("observationRegistry", ObservationRegistry.class, () -> observationRegistry)
-					.withBean("customConvention", PulsarListenerObservationConvention.class, () -> customConvention)
-					.run((context -> assertThat(context).hasNotFailed()
-							.getBean(ConcurrentPulsarListenerContainerFactory.class)
-							.extracting(ConcurrentPulsarListenerContainerFactory<Object>::getContainerProperties)
-							.extracting(PulsarContainerProperties::getObservationConvention)
-							.isSameAs(customConvention)));
+					.run((context -> assertThat(context).getBean(ConcurrentPulsarListenerContainerFactory.class)
+							.hasFieldOrPropertyWithValue("containerProperties.observationEnabled", false)));
 		}
 
 	}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/AbstractPulsarListenerContainerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/AbstractPulsarListenerContainerFactory.java
@@ -24,15 +24,12 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.log.LogAccessor;
-import org.springframework.lang.Nullable;
 import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.listener.AbstractPulsarMessageListenerContainer;
 import org.springframework.pulsar.listener.AckMode;
 import org.springframework.pulsar.listener.PulsarContainerProperties;
 import org.springframework.pulsar.support.JavaUtils;
 import org.springframework.pulsar.support.MessageConverter;
-
-import io.micrometer.observation.ObservationRegistry;
 
 /**
  * Base {@link PulsarListenerContainerFactory} implementation.
@@ -51,8 +48,6 @@ public abstract class AbstractPulsarListenerContainerFactory<C extends AbstractP
 
 	private final PulsarContainerProperties containerProperties;
 
-	private final ObservationRegistry observationRegistry;
-
 	private Boolean autoStartup;
 
 	private Integer phase;
@@ -66,18 +61,13 @@ public abstract class AbstractPulsarListenerContainerFactory<C extends AbstractP
 	private ApplicationContext applicationContext;
 
 	protected AbstractPulsarListenerContainerFactory(PulsarConsumerFactory<? super T> consumerFactory,
-			PulsarContainerProperties containerProperties, @Nullable ObservationRegistry observationRegistry) {
+			PulsarContainerProperties containerProperties) {
 		this.consumerFactory = consumerFactory;
 		this.containerProperties = containerProperties;
-		this.observationRegistry = observationRegistry;
 	}
 
 	protected PulsarConsumerFactory<? super T> getConsumerFactory() {
 		return this.consumerFactory;
-	}
-
-	protected ObservationRegistry getObservationRegistry() {
-		return this.observationRegistry;
 	}
 
 	public PulsarContainerProperties getContainerProperties() {
@@ -171,7 +161,7 @@ public abstract class AbstractPulsarListenerContainerFactory<C extends AbstractP
 		instanceProperties.setMaxNumMessages(this.containerProperties.getMaxNumMessages());
 		instanceProperties.setMaxNumBytes(this.containerProperties.getMaxNumBytes());
 		instanceProperties.setBatchTimeoutMillis(this.containerProperties.getBatchTimeoutMillis());
-		instanceProperties.setObservationConvention(this.containerProperties.getObservationConvention());
+		instanceProperties.setObservationEnabled(this.containerProperties.isObservationEnabled());
 
 		JavaUtils.INSTANCE.acceptIfNotNull(this.phase, instance::setPhase)
 				.acceptIfNotNull(this.applicationContext, instance::setApplicationContext)

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
@@ -19,13 +19,10 @@ package org.springframework.pulsar.listener;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.RedeliveryBackoff;
 
-import org.springframework.lang.Nullable;
 import org.springframework.pulsar.core.AbstractPulsarMessageContainer;
 import org.springframework.pulsar.core.ConsumerBuilderCustomizer;
 import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.util.Assert;
-
-import io.micrometer.observation.ObservationRegistry;
 
 /**
  * Base implementation for the {@link PulsarMessageListenerContainer}.
@@ -40,8 +37,6 @@ public non-sealed abstract class AbstractPulsarMessageListenerContainer<T> exten
 	private final PulsarConsumerFactory<T> pulsarConsumerFactory;
 
 	private final PulsarContainerProperties pulsarContainerProperties;
-
-	private final ObservationRegistry observationRegistry;
 
 	protected final Object lifecycleMonitor = new Object();
 
@@ -59,10 +54,9 @@ public non-sealed abstract class AbstractPulsarMessageListenerContainer<T> exten
 
 	@SuppressWarnings("unchecked")
 	protected AbstractPulsarMessageListenerContainer(PulsarConsumerFactory<? super T> pulsarConsumerFactory,
-			PulsarContainerProperties pulsarContainerProperties, @Nullable ObservationRegistry observationRegistry) {
+			PulsarContainerProperties pulsarContainerProperties) {
 		this.pulsarConsumerFactory = (PulsarConsumerFactory<T>) pulsarConsumerFactory;
 		this.pulsarContainerProperties = pulsarContainerProperties;
-		this.observationRegistry = observationRegistry;
 	}
 
 	public PulsarConsumerFactory<T> getPulsarConsumerFactory() {
@@ -71,10 +65,6 @@ public non-sealed abstract class AbstractPulsarMessageListenerContainer<T> exten
 
 	public PulsarContainerProperties getContainerProperties() {
 		return this.pulsarContainerProperties;
-	}
-
-	public ObservationRegistry getObservationRegistry() {
-		return this.observationRegistry;
 	}
 
 	@Override

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
@@ -33,6 +33,8 @@ import org.springframework.pulsar.core.TopicResolver;
 import org.springframework.pulsar.observation.PulsarListenerObservationConvention;
 import org.springframework.util.Assert;
 
+import io.micrometer.observation.ObservationRegistry;
+
 /**
  * Contains runtime properties for a listener container.
  *
@@ -79,6 +81,10 @@ public class PulsarContainerProperties {
 	private boolean batchListener;
 
 	private AckMode ackMode = AckMode.BATCH;
+
+	private boolean observationEnabled;
+
+	private ObservationRegistry observationRegistry;
 
 	private PulsarListenerObservationConvention observationConvention;
 
@@ -162,6 +168,22 @@ public class PulsarContainerProperties {
 		this.ackMode = ackMode;
 	}
 
+	public boolean isObservationEnabled() {
+		return this.observationEnabled;
+	}
+
+	public void setObservationEnabled(boolean observationEnabled) {
+		this.observationEnabled = observationEnabled;
+	}
+
+	public ObservationRegistry getObservationRegistry() {
+		return this.observationRegistry;
+	}
+
+	void setObservationRegistry(ObservationRegistry observationRegistry) {
+		this.observationRegistry = observationRegistry;
+	}
+
 	public PulsarListenerObservationConvention getObservationConvention() {
 		return this.observationConvention;
 	}
@@ -170,7 +192,7 @@ public class PulsarContainerProperties {
 	 * Set a custom observation convention.
 	 * @param observationConvention the convention.
 	 */
-	public void setObservationConvention(PulsarListenerObservationConvention observationConvention) {
+	void setObservationConvention(PulsarListenerObservationConvention observationConvention) {
 		this.observationConvention = observationConvention;
 	}
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateObservationConfigurationTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateObservationConfigurationTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.pulsar.observation.PulsarTemplateObservationConvention;
+
+import io.micrometer.observation.ObservationRegistry;
+
+/**
+ * Tests for the observation configuration aspect of {@link PulsarTemplate}.
+ *
+ * @author Chris Bono
+ */
+@SuppressWarnings({ "rawtypes", "unchecked" })
+class PulsarTemplateObservationConfigurationTests {
+
+	@Test
+	void uniqueRegistryAndConventionBeansAvailable() {
+		var template = new PulsarTemplate(mock(PulsarProducerFactory.class), Collections.emptyList(),
+				new DefaultSchemaResolver(), new DefaultTopicResolver(), true);
+		var appContext = new GenericApplicationContext();
+		var observationRegistry = mock(ObservationRegistry.class);
+		var observationConvention = mock(PulsarTemplateObservationConvention.class);
+		appContext.registerBean("obsReg", ObservationRegistry.class, () -> observationRegistry);
+		appContext.registerBean("obsConv", PulsarTemplateObservationConvention.class, () -> observationConvention);
+		appContext.refresh();
+		template.setApplicationContext(appContext);
+		template.afterSingletonsInstantiated();
+		assertThat(template).hasFieldOrPropertyWithValue("observationEnabled", true);
+		assertThat(template).hasFieldOrPropertyWithValue("observationRegistry", observationRegistry);
+		assertThat(template).hasFieldOrPropertyWithValue("observationConvention", observationConvention);
+	}
+
+	@Test
+	void enabledPropertySetToFalse() {
+		var template = new PulsarTemplate(mock(PulsarProducerFactory.class), Collections.emptyList(),
+				new DefaultSchemaResolver(), new DefaultTopicResolver(), false);
+		var appContext = new GenericApplicationContext();
+		var observationRegistry = mock(ObservationRegistry.class);
+		var observationConvention = mock(PulsarTemplateObservationConvention.class);
+		appContext.registerBean("obsReg", ObservationRegistry.class, () -> observationRegistry);
+		appContext.registerBean("obsConv", PulsarTemplateObservationConvention.class, () -> observationConvention);
+		appContext.refresh();
+		template.setApplicationContext(appContext);
+		template.afterSingletonsInstantiated();
+		assertThat(template).hasFieldOrPropertyWithValue("observationEnabled", false);
+		assertThat(template).hasFieldOrPropertyWithValue("observationRegistry", null);
+		assertThat(template).hasFieldOrPropertyWithValue("observationConvention", null);
+	}
+
+	@Test
+	void noAppContextAvailable() {
+		var template = new PulsarTemplate(mock(PulsarProducerFactory.class), Collections.emptyList(),
+				new DefaultSchemaResolver(), new DefaultTopicResolver(), true);
+		template.afterSingletonsInstantiated();
+		assertThat(template).hasFieldOrPropertyWithValue("observationEnabled", true);
+		assertThat(template).hasFieldOrPropertyWithValue("observationRegistry", null);
+		assertThat(template).hasFieldOrPropertyWithValue("observationConvention", null);
+	}
+
+	@Test
+	void noRegistryOrConventionBeansAvailable() {
+		var template = new PulsarTemplate(mock(PulsarProducerFactory.class), Collections.emptyList(),
+				new DefaultSchemaResolver(), new DefaultTopicResolver(), true);
+		var appContext = new GenericApplicationContext();
+		appContext.refresh();
+		template.setApplicationContext(appContext);
+		template.afterSingletonsInstantiated();
+		assertThat(template).hasFieldOrPropertyWithValue("observationEnabled", true);
+		assertThat(template).hasFieldOrPropertyWithValue("observationRegistry", null);
+		assertThat(template).hasFieldOrPropertyWithValue("observationConvention", null);
+	}
+
+	@Test
+	void noUniqueRegistryOrConventionBeansAvailable() {
+		var template = new PulsarTemplate(mock(PulsarProducerFactory.class), Collections.emptyList(),
+				new DefaultSchemaResolver(), new DefaultTopicResolver(), true);
+		var appContext = new GenericApplicationContext();
+		var observationRegistry = mock(ObservationRegistry.class);
+		var observationConvention = mock(PulsarTemplateObservationConvention.class);
+		appContext.registerBean("obsReg1", ObservationRegistry.class, () -> observationRegistry);
+		appContext.registerBean("obsReg2", ObservationRegistry.class, () -> observationRegistry);
+		appContext.registerBean("obsConv1", PulsarTemplateObservationConvention.class, () -> observationConvention);
+		appContext.registerBean("obsConv2", PulsarTemplateObservationConvention.class, () -> observationConvention);
+		appContext.refresh();
+		template.setApplicationContext(appContext);
+		template.afterSingletonsInstantiated();
+		assertThat(template).hasFieldOrPropertyWithValue("observationEnabled", true);
+		assertThat(template).hasFieldOrPropertyWithValue("observationRegistry", null);
+		assertThat(template).hasFieldOrPropertyWithValue("observationConvention", null);
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
@@ -221,7 +221,7 @@ class PulsarTemplateTests implements PulsarTestContainerSupport {
 		DefaultTopicResolver topicResolver = new DefaultTopicResolver();
 		topicResolver.addCustomTopicMapping(Foo.class, topic);
 		PulsarTemplate<Foo> pulsarTemplate = new PulsarTemplate<>(producerFactory, Collections.emptyList(),
-				new DefaultSchemaResolver(), topicResolver, null, null);
+				new DefaultSchemaResolver(), topicResolver, false);
 		Foo foo = new Foo("Foo-" + UUID.randomUUID(), "Bar-" + UUID.randomUUID());
 		ThrowingConsumer<PulsarTemplate<Foo>> sendFunction = (template) -> template.send(foo, Schema.JSON(Foo.class));
 		sendAndConsume(pulsarTemplate, sendFunction, topic, Schema.JSON(Foo.class), foo);
@@ -288,7 +288,7 @@ class PulsarTemplateTests implements PulsarTestContainerSupport {
 			DefaultSchemaResolver schemaResolver = new DefaultSchemaResolver();
 			schemaResolver.addCustomSchemaMapping(Foo.class, Schema.JSON(Foo.class));
 			PulsarTemplate<Foo> pulsarTemplate = new PulsarTemplate<>(producerFactory, Collections.emptyList(),
-					schemaResolver, new DefaultTopicResolver(), null, null);
+					schemaResolver, new DefaultTopicResolver(), false);
 			Foo foo = new Foo("Foo-" + UUID.randomUUID(), "Bar-" + UUID.randomUUID());
 			ThrowingConsumer<PulsarTemplate<Foo>> sendFunction = (template) -> template.newMessage(foo).send();
 			sendAndConsume(pulsarTemplate, sendFunction, topic, Schema.JSON(Foo.class), foo);

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -128,7 +128,7 @@ public class PulsarListenerTests implements PulsarTestContainerSupport {
 		PulsarListenerContainerFactory pulsarListenerContainerFactory(
 				PulsarConsumerFactory<Object> pulsarConsumerFactory) {
 			ConcurrentPulsarListenerContainerFactory<?> pulsarListenerContainerFactory = new ConcurrentPulsarListenerContainerFactory<>(
-					pulsarConsumerFactory, new PulsarContainerProperties(), null);
+					pulsarConsumerFactory, new PulsarContainerProperties());
 			return pulsarListenerContainerFactory;
 		}
 
@@ -707,7 +707,7 @@ public class PulsarListenerTests implements PulsarTestContainerSupport {
 				PulsarContainerProperties containerProps = new PulsarContainerProperties();
 				containerProps.setSchemaResolver(schemaResolver);
 				ConcurrentPulsarListenerContainerFactory<?> pulsarListenerContainerFactory = new ConcurrentPulsarListenerContainerFactory<>(
-						pulsarConsumerFactory, containerProps, null);
+						pulsarConsumerFactory, containerProps);
 				return pulsarListenerContainerFactory;
 			}
 
@@ -787,7 +787,7 @@ public class PulsarListenerTests implements PulsarTestContainerSupport {
 				PulsarContainerProperties containerProps = new PulsarContainerProperties();
 				containerProps.setTopicResolver(topicResolver);
 				ConcurrentPulsarListenerContainerFactory<?> pulsarListenerContainerFactory = new ConcurrentPulsarListenerContainerFactory<>(
-						pulsarConsumerFactory, containerProps, null);
+						pulsarConsumerFactory, containerProps);
 				return pulsarListenerContainerFactory;
 			}
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/observation/ObservationIntegrationTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/observation/ObservationIntegrationTests.java
@@ -140,10 +140,9 @@ public class ObservationIntegrationTests extends SampleTestRunner implements Pul
 		}
 
 		@Bean
-		public PulsarTemplate<String> pulsarTemplate(PulsarProducerFactory<String> pulsarProducerFactory,
-				ObservationRegistry observationRegistry) {
+		public PulsarTemplate<String> pulsarTemplate(PulsarProducerFactory<String> pulsarProducerFactory) {
 			return new PulsarTemplate<>(pulsarProducerFactory, null, new DefaultSchemaResolver(),
-					new DefaultTopicResolver(), observationRegistry, null);
+					new DefaultTopicResolver(), true);
 		}
 
 		@Bean
@@ -153,9 +152,10 @@ public class ObservationIntegrationTests extends SampleTestRunner implements Pul
 
 		@Bean
 		PulsarListenerContainerFactory pulsarListenerContainerFactory(
-				PulsarConsumerFactory<Object> pulsarConsumerFactory, ObservationRegistry observationRegistry) {
-			return new ConcurrentPulsarListenerContainerFactory<>(pulsarConsumerFactory,
-					new PulsarContainerProperties(), observationRegistry);
+				PulsarConsumerFactory<Object> pulsarConsumerFactory) {
+			PulsarContainerProperties containerProps = new PulsarContainerProperties();
+			containerProps.setObservationEnabled(true);
+			return new ConcurrentPulsarListenerContainerFactory<>(pulsarConsumerFactory, containerProps);
 		}
 
 		@Bean


### PR DESCRIPTION
* Remove observation registry and convention from constructors on PulsarTemplate and CPLCF
* Lookup observation registry and convention from app context at start time

As described [here](https://github.com/spring-projects/spring-boot/pull/34763#discussion_r1148417303)