### PR TITLE
Add tlsCertificateFilePath/tlsKeyFilePath config

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,7 +2,7 @@ name: CI PRs
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ "main", "0.2.x" ]
     paths-ignore:
       - '.github/**'
 env:

--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarProperties.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarProperties.java
@@ -261,6 +261,16 @@ public class PulsarProperties {
 		private String tlsTrustCertsFilePath;
 
 		/**
+		 * Path for the TLS certificate file.
+		 */
+		private String tlsCertificateFilePath;
+
+		/**
+		 * Path for the TLS private key file.
+		 */
+		private String tlsKeyFilePath;
+
+		/**
 		 * Whether the client accepts untrusted TLS certificates from the broker.
 		 */
 		private Boolean tlsAllowInsecureConnection = false;
@@ -523,6 +533,22 @@ public class PulsarProperties {
 			this.tlsTrustCertsFilePath = tlsTrustCertsFilePath;
 		}
 
+		public String getTlsCertificateFilePath() {
+			return this.tlsCertificateFilePath;
+		}
+
+		public void setTlsCertificateFilePath(String tlsCertificateFilePath) {
+			this.tlsCertificateFilePath = tlsCertificateFilePath;
+		}
+
+		public String getTlsKeyFilePath() {
+			return this.tlsKeyFilePath;
+		}
+
+		public void setTlsKeyFilePath(String tlsKeyFilePath) {
+			this.tlsKeyFilePath = tlsKeyFilePath;
+		}
+
 		public Boolean getTlsAllowInsecureConnection() {
 			return this.tlsAllowInsecureConnection;
 		}
@@ -771,6 +797,8 @@ public class PulsarProperties {
 			map.from(this::getUseTls).to(properties.in("useTls"));
 			map.from(this::getTlsHostnameVerificationEnable).to(properties.in("tlsHostnameVerificationEnable"));
 			map.from(this::getTlsTrustCertsFilePath).to(properties.in("tlsTrustCertsFilePath"));
+			map.from(this::getTlsCertificateFilePath).to(properties.in("tlsCertificateFilePath"));
+			map.from(this::getTlsKeyFilePath).to(properties.in("tlsKeyFilePath"));
 			map.from(this::getTlsAllowInsecureConnection).to(properties.in("tlsAllowInsecureConnection"));
 			map.from(this::getUseKeyStoreTls).to(properties.in("useKeyStoreTls"));
 			map.from(this::getSslProvider).to(properties.in("sslProvider"));
@@ -966,6 +994,16 @@ public class PulsarProperties {
 		private String tlsTrustCertsFilePath;
 
 		/**
+		 * Path for the TLS certificate file.
+		 */
+		private String tlsCertificateFilePath;
+
+		/**
+		 * Path for the TLS private key file.
+		 */
+		private String tlsKeyFilePath;
+
+		/**
 		 * Whether the client accepts untrusted TLS certificates from the broker.
 		 */
 		private Boolean tlsAllowInsecureConnection = false;
@@ -1073,6 +1111,22 @@ public class PulsarProperties {
 
 		public void setTlsTrustCertsFilePath(String tlsTrustCertsFilePath) {
 			this.tlsTrustCertsFilePath = tlsTrustCertsFilePath;
+		}
+
+		public String getTlsCertificateFilePath() {
+			return this.tlsCertificateFilePath;
+		}
+
+		public void setTlsCertificateFilePath(String tlsCertificateFilePath) {
+			this.tlsCertificateFilePath = tlsCertificateFilePath;
+		}
+
+		public String getTlsKeyFilePath() {
+			return this.tlsKeyFilePath;
+		}
+
+		public void setTlsKeyFilePath(String tlsKeyFilePath) {
+			this.tlsKeyFilePath = tlsKeyFilePath;
 		}
 
 		public Boolean isTlsAllowInsecureConnection() {
@@ -1193,6 +1247,8 @@ public class PulsarProperties {
 			map.from(this::getAuthentication).as(AuthParameterUtils::maybeConvertToEncodedParamString)
 					.to(properties.in("authParams"));
 			map.from(this::getTlsTrustCertsFilePath).to(properties.in("tlsTrustCertsFilePath"));
+			map.from(this::getTlsCertificateFilePath).to(properties.in("tlsCertificateFilePath"));
+			map.from(this::getTlsKeyFilePath).to(properties.in("tlsKeyFilePath"));
 			map.from(this::isTlsAllowInsecureConnection).to(properties.in("tlsAllowInsecureConnection"));
 			map.from(this::isTlsHostnameVerificationEnable).to(properties.in("tlsHostnameVerificationEnable"));
 			map.from(this::isUseKeyStoreTls).to(properties.in("useKeyStoreTls"));

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarPropertiesTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarPropertiesTests.java
@@ -95,6 +95,8 @@ public class PulsarPropertiesTests {
 			props.put("spring.pulsar.client.use-tls", "true");
 			props.put("spring.pulsar.client.tls-hostname-verification-enable", "true");
 			props.put("spring.pulsar.client.tls-trust-certs-file-path", "my-trust-certs-file-path");
+			props.put("spring.pulsar.client.tls-certificate-file-path", "my-certificate-file-path");
+			props.put("spring.pulsar.client.tls-key-file-path", "my-key-file-path");
 			props.put("spring.pulsar.client.tls-allow-insecure-connection", "true");
 			props.put("spring.pulsar.client.use-key-store-tls", "true");
 			props.put("spring.pulsar.client.ssl-provider", "my-ssl-provider");
@@ -137,6 +139,8 @@ public class PulsarPropertiesTests {
 					.containsEntry("useTcpNoDelay", false).containsEntry("useTls", true)
 					.containsEntry("tlsHostnameVerificationEnable", true)
 					.containsEntry("tlsTrustCertsFilePath", "my-trust-certs-file-path")
+					.containsEntry("tlsCertificateFilePath", "my-certificate-file-path")
+					.containsEntry("tlsKeyFilePath", "my-key-file-path")
 					.containsEntry("tlsAllowInsecureConnection", true).containsEntry("useKeyStoreTls", true)
 					.containsEntry("sslProvider", "my-ssl-provider")
 					.containsEntry("tlsTrustStoreType", "my-trust-store-type")
@@ -226,6 +230,8 @@ public class PulsarPropertiesTests {
 			props.put("spring.pulsar.administration.auto-cert-refresh-time", "15s");
 			props.put("spring.pulsar.administration.tls-hostname-verification-enable", "true");
 			props.put("spring.pulsar.administration.tls-trust-certs-file-path", "my-trust-certs-file-path");
+			props.put("spring.pulsar.administration.tls-certificate-file-path", "my-certificate-file-path");
+			props.put("spring.pulsar.administration.tls-key-file-path", "my-key-file-path");
 			props.put("spring.pulsar.administration.tls-allow-insecure-connection", "true");
 			props.put("spring.pulsar.administration.use-key-store-tls", "true");
 			props.put("spring.pulsar.administration.ssl-provider", "my-ssl-provider");
@@ -249,6 +255,8 @@ public class PulsarPropertiesTests {
 					.containsEntry("requestTimeoutMs", 14_000).containsEntry("autoCertRefreshSeconds", 15)
 					.containsEntry("tlsHostnameVerificationEnable", true)
 					.containsEntry("tlsTrustCertsFilePath", "my-trust-certs-file-path")
+					.containsEntry("tlsCertificateFilePath", "my-certificate-file-path")
+					.containsEntry("tlsKeyFilePath", "my-key-file-path")
 					.containsEntry("tlsAllowInsecureConnection", true).containsEntry("useKeyStoreTls", true)
 					.containsEntry("sslProvider", "my-ssl-provider")
 					.containsEntry("tlsTrustStoreType", "my-trust-store-type")


### PR DESCRIPTION
Add missing tlsCertificateFilePath/tlsKeyFilePath configs which are needed to configure mutual TLS encryption by itself (without authentication plugin).

resolves #374 