### PR TITLE
Use shaded cache module for Reactive client

### DIFF
--- a/spring-pulsar-dependencies/build.gradle
+++ b/spring-pulsar-dependencies/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 		api "com.google.protobuf:protobuf-java:$protobufJavaVersion"
 		api "org.apache.pulsar:pulsar-client-all:$pulsarVersion"
 		api "org.apache.pulsar:pulsar-client-reactive-adapter:$pulsarClientReactiveVersion"
-		api "org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine:$pulsarClientReactiveVersion"
+		api "org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded:$pulsarClientReactiveVersion"
 		api "org.springframework.cloud:spring-cloud-stream:$springCloudStreamVersion"
 		api "org.springframework.cloud:spring-cloud-stream-test-support:$springCloudStreamVersion"
 		api "org.springframework.pulsar:spring-pulsar-spring-boot-starter:$springPulsarStarterVersion"

--- a/spring-pulsar-reactive/build.gradle
+++ b/spring-pulsar-reactive/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 		// spring-pulsar includes a pulsar-client with its unwanted transitive deps excluded
 		exclude group: "org.apache.pulsar", module: "pulsar-client"
 	}
-	implementation("org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded") {
+	api("org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded") {
 		// (above) we include a pulsar-client-reactive-adapter whose pulsar-client with
 		// unwanted transitive deps excluded
 		exclude group: "org.apache.pulsar", module: "pulsar-client-reactive-adapter"

--- a/spring-pulsar-reactive/build.gradle
+++ b/spring-pulsar-reactive/build.gradle
@@ -7,7 +7,15 @@ description = 'Spring Pulsar Reactive Support'
 
 dependencies {
 	api project (':spring-pulsar')
-	api 'org.apache.pulsar:pulsar-client-reactive-adapter'
+	api ('org.apache.pulsar:pulsar-client-reactive-adapter') {
+		// spring-pulsar includes a pulsar-client with its unwanted transitive deps excluded
+		exclude group: "org.apache.pulsar", module: "pulsar-client"
+	}
+	implementation("org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded") {
+		// (above) we include a pulsar-client-reactive-adapter whose pulsar-client with
+		// unwanted transitive deps excluded
+		exclude group: "org.apache.pulsar", module: "pulsar-client-reactive-adapter"
+	}
 	implementation 'com.fasterxml.jackson.core:jackson-core'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'com.google.code.findbugs:jsr305'
@@ -17,7 +25,6 @@ dependencies {
 	optional 'com.google.protobuf:protobuf-java'
 	optional 'com.jayway.jsonpath:json-path'
 	optional 'io.projectreactor:reactor-core'
-	optional 'org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine'
 
 	testImplementation project(':spring-pulsar-test')
 	testRuntimeOnly 'ch.qos.logback:logback-classic'


### PR DESCRIPTION
- use `pulsar-client-reactive-producer-cache-caffeine-shaded`
- exclude `pulsar-client` from reactive client modules as it brings in unwanted transitive deps

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
