### PR TITLE
Remove use of Spring Boot test module

### DIFF
--- a/integration-tests/integration-tests.gradle
+++ b/integration-tests/integration-tests.gradle
@@ -6,6 +6,12 @@ plugins {
 
 description = 'Spring Pulsar Integration Tests'
 
+repositories {
+	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
+	maven { url 'https://repo.spring.io/snapshot' }
+}
+
 dependencies {
 	intTestImplementation project(':spring-pulsar-test')
 	intTestRuntimeOnly 'ch.qos.logback:logback-classic'

--- a/spring-pulsar/spring-pulsar.gradle
+++ b/spring-pulsar/spring-pulsar.gradle
@@ -41,6 +41,6 @@ dependencies {
 	testImplementation 'org.mockito:mockito-junit-jupiter'
 	testImplementation 'org.springframework:spring-test'
 
-	// OutputCaptureExtension used by PulsarFunctionAdministrationTests
-	testImplementation "org.springframework.boot:spring-boot-test:$springBootVersion"
+	// Output capture used by PulsarFunctionAdministrationTests
+	testImplementation group: 'com.github.stefanbirkner', name: 'system-lambda', version: '1.2.1'
 }


### PR DESCRIPTION
This PR replaces use of Spring Boot test module.

- [x] Replace OutputCaptureExtension use in `PulsarFunctionAdministrationTests` with system-lambda.
- [x] Allow usages in integration-test