### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         name: Extract current version
         run: |
           version=$(cat gradle.properties | grep "version=" | awk -F'=' '{print $2}')
-          echo "::set-output name=project_version::$version"
+          echo "project_version=$version" >> $GITHUB_OUTPUT
 
   perform_release:
     name: Perform Release

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,7 +36,7 @@ jobs:
         name: Check for open issues
         run: |
           echo "TODO actually check for open issues"
-          echo "::set-output name=is_open_issues::false"
+          echo "is_open_issues=false" >> $GITHUB_OUTPUT
 
       - id: validate-release-state
         name: Validate release state


### PR DESCRIPTION
## Description

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=project_version::$version"
```

**TO-BE**

```yaml
echo "project_version=$version" >> $GITHUB_OUTPUT
```