### PR TITLE
Update Pulsar binder to SCSt 4.1.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,12 +6,8 @@ org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Df
 
 pulsarClientVersion=3.1.0
 pulsarClientReactiveVersion=0.3.0
+springFrameworkVersion=6.1.0-M4
 
 # only used by docs, tests, and samples (unpublished deps)
 springBootVersion=3.2.0-SNAPSHOT
-
-springFrameworkVersion=6.1.0-M4
-
-# these are temp until autoconfig moves into boot
-springPulsarBinderVersion=0.2.1-SNAPSHOT
-springCloudStreamVersion=4.0.3
+springCloudStreamVersion=4.1.0-SNAPSHOT

--- a/spring-pulsar-docs/spring-pulsar-docs.gradle
+++ b/spring-pulsar-docs/spring-pulsar-docs.gradle
@@ -89,7 +89,6 @@ tasks.withType(org.asciidoctor.gradle.jvm.AbstractAsciidoctorTask) {
 				"spring-framework-version": project.springFrameworkVersion ?: 'current',
 				"spring-cloud-stream-version": project.springCloudStreamVersion ?: 'current',
 				"spring-pulsar-version": project.version,
-				"spring-pulsar-binder-version": project.springPulsarBinderVersion ?: 'current',
 				"pulsar-client-version": project.pulsarClientVersion ?: 'current',
 				"pulsar-client-reactive-version": project.pulsarClientReactiveVersion ?: 'current',
 				"is-snapshot-version": project.version.endsWith("-SNAPSHOT")

--- a/spring-pulsar-docs/src/main/asciidoc/attributes-variables.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/attributes-variables.adoc
@@ -2,7 +2,6 @@
 :spring-framework-version: current
 :spring-cloud-stream-version: current
 :spring-pulsar-version: current
-:spring-pulsar-binder-version: current
 :pulsar-client-version: current
 :pulsar-client-reactive-version: current
 :is-snapshot-version:  false

--- a/spring-pulsar-docs/src/main/asciidoc/pulsar-binder.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/pulsar-binder.adoc
@@ -16,9 +16,9 @@ We need to include the following dependency on your application to use Apache Pu
 ----
 <dependencies>
     <dependency>
-        <groupId>org.springframework.pulsar</groupId>
-        <artifactId>spring-pulsar-spring-cloud-stream-binder</artifactId>
-        <version>{spring-pulsar-binder-version}</version>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-stream-binder-pulsar</artifactId>
+        <version>{spring-cloud-stream-version}</version>
     </dependency>
 </dependencies>
 ----
@@ -27,7 +27,7 @@ We need to include the following dependency on your application to use Apache Pu
 .Gradle
 ----
 dependencies {
-    implementation 'org.springframework.pulsar:spring-pulsar-spring-cloud-stream-binder:{spring-pulsar-binder-version}'
+    implementation 'org.springframework.cloud:spring-cloud-stream-binder-pulsar:{spring-cloud-stream-version}'
 }
 ----
 

--- a/spring-pulsar-sample-apps/sample-pulsar-binder/build.gradle
+++ b/spring-pulsar-sample-apps/sample-pulsar-binder/build.gradle
@@ -14,7 +14,7 @@ repositories {
 
 dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-pulsar:${springBootVersion}"
-	implementation "org.springframework.pulsar:spring-pulsar-spring-cloud-stream-binder:${springPulsarBinderVersion}"
+	implementation "org.springframework.cloud:spring-cloud-stream-binder-pulsar:${springCloudStreamVersion}"
 }
 
 bootRun {

--- a/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-app/build.gradle
+++ b/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-app/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-	implementation "org.springframework.pulsar:spring-pulsar-spring-cloud-stream-binder:${springPulsarBinderVersion}"
+	implementation "org.springframework.cloud:spring-cloud-stream-binder-pulsar:${springCloudStreamVersion}"
 	implementation "org.springframework.boot:spring-boot-starter-pulsar:${springBootVersion}"
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	implementation 'org.springframework.boot:spring-boot-starter-data-cassandra'


### PR DESCRIPTION
The Pulsar binder moved from this repo to SCSt repo. This commit updates to use the new Pulsar binder.
