### PR TITLE
Move cache provider into proper package.

### DIFF
--- a/spring-pulsar-cache-provider-caffeine/src/main/java/org/springframework/pulsar/cache/provider/caffeine/CaffeineCacheProvider.java
+++ b/spring-pulsar-cache-provider-caffeine/src/main/java/org/springframework/pulsar/cache/provider/caffeine/CaffeineCacheProvider.java
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-package org.springframework.pulsar.core;
+package org.springframework.pulsar.cache.provider.caffeine;
 
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+
+import org.springframework.pulsar.cache.provider.CacheProvider;
 
 import com.github.benmanes.caffeine.cache.Cache;
 

--- a/spring-pulsar-cache-provider-caffeine/src/main/java/org/springframework/pulsar/cache/provider/caffeine/CaffeineCacheProviderFactory.java
+++ b/spring-pulsar-cache-provider-caffeine/src/main/java/org/springframework/pulsar/cache/provider/caffeine/CaffeineCacheProviderFactory.java
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-package org.springframework.pulsar.core;
+package org.springframework.pulsar.cache.provider.caffeine;
 
 import java.time.Duration;
+
+import org.springframework.pulsar.cache.provider.CacheProvider;
+import org.springframework.pulsar.cache.provider.CacheProviderFactory;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;

--- a/spring-pulsar-cache-provider-caffeine/src/main/resources/META-INF/services/org.springframework.pulsar.cache.provider.CacheProviderFactory
+++ b/spring-pulsar-cache-provider-caffeine/src/main/resources/META-INF/services/org.springframework.pulsar.cache.provider.CacheProviderFactory
@@ -1,0 +1,1 @@
+org.springframework.pulsar.cache.provider.caffeine.CaffeineCacheProviderFactory

--- a/spring-pulsar-cache-provider-caffeine/src/main/resources/META-INF/services/org.springframework.pulsar.core.CacheProviderFactory
+++ b/spring-pulsar-cache-provider-caffeine/src/main/resources/META-INF/services/org.springframework.pulsar.core.CacheProviderFactory
@@ -1,1 +1,0 @@
-org.springframework.pulsar.core.CaffeineCacheProviderFactory

--- a/spring-pulsar-cache-provider/src/main/java/org/springframework/pulsar/cache/provider/CacheProvider.java
+++ b/spring-pulsar-cache-provider/src/main/java/org/springframework/pulsar/cache/provider/CacheProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.pulsar.core;
+package org.springframework.pulsar.cache.provider;
 
 import java.util.Map;
 import java.util.function.BiConsumer;

--- a/spring-pulsar-cache-provider/src/main/java/org/springframework/pulsar/cache/provider/CacheProviderFactory.java
+++ b/spring-pulsar-cache-provider/src/main/java/org/springframework/pulsar/cache/provider/CacheProviderFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.pulsar.core;
+package org.springframework.pulsar.cache.provider;
 
 import java.time.Duration;
 import java.util.ServiceLoader;

--- a/spring-pulsar-cache-provider/src/test/java/org/springframework/pulsar/cache/provider/CacheProviderFactoryTests.java
+++ b/spring-pulsar-cache-provider/src/test/java/org/springframework/pulsar/cache/provider/CacheProviderFactoryTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.pulsar.core;
+package org.springframework.pulsar.cache.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring-pulsar-cache-provider/src/test/resources/META-INF/services/org.springframework.pulsar.cache.provider.CacheProviderFactory
+++ b/spring-pulsar-cache-provider/src/test/resources/META-INF/services/org.springframework.pulsar.cache.provider.CacheProviderFactory
@@ -1,0 +1,1 @@
+org.springframework.pulsar.cache.provider.CacheProviderFactoryTests$TestCacheProviderFactory

--- a/spring-pulsar-cache-provider/src/test/resources/META-INF/services/org.springframework.pulsar.core.CacheProviderFactory
+++ b/spring-pulsar-cache-provider/src/test/resources/META-INF/services/org.springframework.pulsar.core.CacheProviderFactory
@@ -1,1 +1,0 @@
-org.springframework.pulsar.core.CacheProviderFactoryTests$TestCacheProviderFactory

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/CachingPulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/CachingPulsarProducerFactory.java
@@ -38,6 +38,8 @@ import org.apache.pulsar.common.protocol.schema.SchemaHash;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
+import org.springframework.pulsar.cache.provider.CacheProvider;
+import org.springframework.pulsar.cache.provider.CacheProviderFactory;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.lang.Nullable;
+import org.springframework.pulsar.cache.provider.CacheProvider;
 import org.springframework.pulsar.core.CachingPulsarProducerFactory.ProducerCacheKey;
 import org.springframework.pulsar.core.CachingPulsarProducerFactory.ProducerWithCloseCallback;
 import org.springframework.test.util.ReflectionTestUtils;


### PR DESCRIPTION
The cache provider modules source files were previously packaged under the `spring.pulsar.core` name. 

This moves them to a package name that is specific to their module name. 

The motiivation of the change is to pre-emptively reduce confusion w/ the Java module system.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
