### PR TITLE
Remove reflective cache clear on Reactive sender

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarSenderFactory.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarSenderFactory.java
@@ -35,7 +35,6 @@ import org.springframework.pulsar.core.DefaultTopicResolver;
 import org.springframework.pulsar.core.TopicResolver;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.ReflectionUtils;
 
 /**
  * Default implementation of {@link ReactivePulsarSenderFactory}.
@@ -173,75 +172,12 @@ public final class DefaultReactivePulsarSenderFactory<T>
 	@Override
 	public void doStop() {
 		try {
-			this.reflectivelyClearCache();
 			this.reactiveMessageSenderCache.close();
 
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
-	}
-
-	/**
-	 * Workaround to reflectively clear the underlying producer cache.
-	 *
-	 * TODO: Remove once this is supported in the Reactive client.
-	 */
-	private void reflectivelyClearCache() {
-		if (this.reactiveMessageSenderCache == null) {
-			this.logger.trace(() -> "Cache is null - nothing to clear");
-			return;
-		}
-
-		// reactiveMessageSenderCache
-		// (org.apache.pulsar.reactive.client.internal.adapter.ProducerCache)
-		var cacheProviderField = ReflectionUtils.findField(this.reactiveMessageSenderCache.getClass(), "cacheProvider");
-		if (cacheProviderField == null) {
-			this.logger.trace(
-					() -> "Could not locate 'cacheProvider' field on sender cache: " + this.reactiveMessageSenderCache);
-			return;
-		}
-		ReflectionUtils.makeAccessible(cacheProviderField);
-		// org.apache.pulsar.reactive.client.producercache.CaffeineShadedProducerCacheProvider
-		var cacheProvider = ReflectionUtils.getField(cacheProviderField, this.reactiveMessageSenderCache);
-		if (cacheProvider == null) {
-			this.logger.trace(() -> "Cache provider was null on sender cache: " + this.reactiveMessageSenderCache);
-			return;
-		}
-
-		// org.apache.pulsar.reactive.shade.com.github.benmanes.caffeine.cache.BoundedLocalCache$BoundedLocalAsyncCache
-		var cacheField = ReflectionUtils.findField(cacheProvider.getClass(), "cache");
-		if (cacheField == null) {
-			this.logger.trace(() -> "Could not locate 'cache' field on cache provider: " + cacheProvider);
-			return;
-		}
-		ReflectionUtils.makeAccessible(cacheField);
-		var cache = ReflectionUtils.getField(cacheField, cacheProvider);
-		if (cacheField == null) {
-			this.logger.trace(() -> "Cache impl was null on cache provider: " + cacheProvider);
-			return;
-		}
-
-		// org.apache.pulsar.reactive.shade.com.github.benmanes.caffeine.cache.SSLMSAW
-		var actualCacheField = ReflectionUtils.findField(cache.getClass(), "cache");
-		if (actualCacheField == null) {
-			this.logger.trace(() -> "Could not locate 'cache' field on cache impl: " + cache);
-			return;
-		}
-		ReflectionUtils.makeAccessible(actualCacheField);
-		var actualCache = ReflectionUtils.getField(actualCacheField, cache);
-		if (actualCache == null) {
-			this.logger.trace(() -> "Actual cache was null on cache impl: " + cache);
-			return;
-		}
-
-		var clearMethod = ReflectionUtils.findMethod(actualCache.getClass(), "clear");
-		if (clearMethod == null) {
-			this.logger.trace(() -> "Could not locate 'clear' method on actual cache: " + actualCache);
-			return;
-		}
-		ReflectionUtils.makeAccessible(clearMethod);
-		ReflectionUtils.invokeMethod(clearMethod, actualCache);
 	}
 
 	/**


### PR DESCRIPTION
As it turns out the closeable() implementation of the reactive sender cache is properly clearing the cache therefore the reflective manual clear is not needed.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
