### PR TITLE
Add subscription name generator support

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar.adoc
@@ -175,8 +175,21 @@ public void listen(String message) {
 }
 ----
 
-In this most basic form, when the `subscriptionName` is not provided on the `@PulsarListener` annotation an auto-generated subscription name will be used.
-Likewise, when the `topics` are not directly provided, a <<topic-resolution-process-imperative,topic resolution process>> is used to determine the destination topic.
+In this most basic form, when the `topics` are not directly provided, a <<topic-resolution-process-imperative,topic resolution process>> is used to determine the destination topic.
+Likewise, when the `subscriptionName` is not provided on the `@PulsarListener` annotation an auto-generated subscription name will be used.
+The default generated name is some prefix appended with an incrementing counter.
+To customize the name generation you can register a `PulsarEndpointSubscriptionNameGenerator` bean, for example:
+
+[source, java]
+----
+@Bean
+PulsarEndpointSubscriptionNameGenerator<PulsarListener> customSubNameGenerator() {
+    return endpointSpecifier -> {
+        var listenerId = endpointSpecifier.id();
+        return Optional.of(listenerId + "-sub-" + System.currentTimeMillis());
+    };
+}
+----
 
 In the `PulsarListener` method shown earlier, we receive the data as `String`, but we do not specify any schema types.
 Internally, the framework relies on Pulsar's schema mechanism to convert the data to the required type.

--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/reactive-pulsar.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/reactive-pulsar.adoc
@@ -159,8 +159,20 @@ Mono<Void> listen(String message) {
 }
 ----
 
-In this most basic form, when the `subscriptionName` is not provided on the `@ReactivePulsarListener` annotation an auto-generated subscription name will be used.
-Likewise, when the `topics` are not directly provided, a <<topic-resolution-process-reactive,topic resolution process>> is used to determine the destination topic.
+In this most basic form, when the `topics` are not directly provided, a <<topic-resolution-process-reactive,topic resolution process>> is used to determine the destination topic.
+Likewise, when the `subscriptionName` is not provided on the `@ReactivePulsarListener` annotation an auto-generated subscription name will be used.
+The default generated name is some prefix appended with an incrementing counter.
+To customize the name generation you can register a `PulsarEndpointSubscriptionNameGenerator` bean, for example:
+[source, java]
+----
+@Bean
+PulsarEndpointSubscriptionNameGenerator<ReactivePulsarListener> customSubNameGenerator() {
+    return endpointSpecifier -> {
+        var listenerId = endpointSpecifier.id();
+        return Optional.of(listenerId + "-sub-" + System.currentTimeMillis());
+    };
+}
+----
 
 In the `ReactivePulsarListener` method shown earlier, we receive the data as `String`, but we do not specify any schema types.
 Internally, the framework relies on Pulsar's schema mechanism to convert the data to the required type.

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
@@ -154,7 +154,8 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V> extends Abstra
 					});
 			if (annotatedMethods.isEmpty()) {
 				this.nonAnnotatedClasses.add(bean.getClass());
-				this.logger.trace(() -> "No @PulsarListener annotations found on bean type: " + bean.getClass());
+				this.logger
+					.trace(() -> "No @ReactivePulsarListener annotations found on bean type: " + bean.getClass());
 			}
 			else {
 				// Non-empty set of methods
@@ -233,7 +234,7 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V> extends Abstra
 
 		endpoint.setBean(bean);
 		endpoint.setMessageHandlerMethodFactory(this.messageHandlerMethodFactory);
-		endpoint.setSubscriptionName(getEndpointSubscriptionName(reactivePulsarListener));
+		resolveSubscriptionName(endpoint, reactivePulsarListener);
 		endpoint.setId(getEndpointId(reactivePulsarListener));
 		endpoint.setTopics(topics);
 		endpoint.setTopicPattern(topicPattern);
@@ -294,11 +295,10 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V> extends Abstra
 		}
 	}
 
-	private String getEndpointSubscriptionName(ReactivePulsarListener reactivePulsarListener) {
-		if (StringUtils.hasText(reactivePulsarListener.subscriptionName())) {
-			return resolveExpressionAsString(reactivePulsarListener.subscriptionName(), "subscriptionName");
-		}
-		return GENERATED_ID_PREFIX + this.counter.getAndIncrement();
+	private void resolveSubscriptionName(MethodReactivePulsarListenerEndpoint<?> endpoint,
+			ReactivePulsarListener reactivePulsarListener) {
+		endpoint.setSubscriptionName(determineEndpointSubscriptionName(reactivePulsarListener,
+				reactivePulsarListener.subscriptionName(), () -> GENERATED_ID_PREFIX + this.counter.getAndIncrement()));
 	}
 
 	private String getEndpointId(ReactivePulsarListener reactivePulsarListener) {

--- a/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/ReactivePulsarListenerSubscriptionNameTests.java
+++ b/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/ReactivePulsarListenerSubscriptionNameTests.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.reactive.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.pulsar.reactive.listener.ReactivePulsarListenerSubscriptionNameTests.WithNameGenerator.WithNameGeneratorConfig;
+import static org.springframework.pulsar.reactive.listener.ReactivePulsarListenerSubscriptionNameTests.WithoutNameGenerator.WithoutNameGeneratorConfig;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.pulsar.config.PulsarEndpointSubscriptionNameGenerator;
+import org.springframework.pulsar.reactive.config.ReactivePulsarListenerEndpointRegistry;
+import org.springframework.pulsar.reactive.config.annotation.ReactivePulsarListener;
+import org.springframework.test.context.ContextConfiguration;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Tests for the subscription name setting on the
+ * {@link ReactivePulsarListener @ReactivePulsarListener}.
+ *
+ * @author Chris Bono
+ */
+class ReactivePulsarListenerSubscriptionNameTests extends ReactivePulsarListenerTestsBase {
+
+	@Nested
+	@ContextConfiguration(classes = WithoutNameGeneratorConfig.class)
+	class WithoutNameGenerator {
+
+		static final CountDownLatch latchNameNotSet = new CountDownLatch(1);
+		static final CountDownLatch latchNameSet = new CountDownLatch(1);
+		static final CountDownLatch latchNameExprSet = new CountDownLatch(1);
+		static final CountDownLatch latchWithCustomizer = new CountDownLatch(1);
+
+		@Autowired
+		protected ReactivePulsarListenerEndpointRegistry<String> registry;
+
+		@Test
+		void whenNameNotSetOnAnnotationThenDefaultGeneratedNameIsUsed() throws Exception {
+			assertSubscriptionName("nameNotSet-id")
+				.startsWith("org.springframework.Pulsar.ReactivePulsarListenerEndpointContainer#");
+			pulsarTemplate.send("nameNotSet-topic", "hello-nameNotSet");
+			assertThat(latchNameNotSet.await(5, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Test
+		void whenNameSetOnAnnotationThenSpecifiedNameIsUsed() throws Exception {
+			assertSubscriptionName("nameSet-id").isEqualTo("nameSet-sub");
+			pulsarTemplate.send("nameSet-topic", "hello-nameSet");
+			assertThat(latchNameSet.await(5, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Test
+		void whenNameExprSetOnAnnotationThenEvaluatedNameIsUsed() throws Exception {
+			assertSubscriptionName("nameExprSet-id").isEqualTo("nameExprSet-sub");
+			pulsarTemplate.send("nameExprSet-topic", "hello-nameExprSet");
+			assertThat(latchNameExprSet.await(5, TimeUnit.SECONDS)).isTrue();
+		}
+
+		private AbstractStringAssert<?> assertSubscriptionName(String containerId) {
+			return assertThat(registry.getListenerContainer(containerId).getContainerProperties())
+				.extracting(ReactivePulsarContainerProperties::getSubscriptionName, InstanceOfAssertFactories.STRING);
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		static class WithoutNameGeneratorConfig {
+
+			@ReactivePulsarListener(id = "nameNotSet-id", topics = "nameNotSet-topic")
+			Mono<Void> listenWithoutNameSet(String ignored) {
+				latchNameNotSet.countDown();
+				return Mono.empty();
+			}
+
+			@ReactivePulsarListener(id = "nameSet-id", topics = "nameSet-topic", subscriptionName = "nameSet-sub")
+			Mono<Void> listenWithNameSet(String ignored) {
+				latchNameSet.countDown();
+				return Mono.empty();
+			}
+
+			@ReactivePulsarListener(id = "nameExprSet-id", topics = "nameExprSet-topic",
+					subscriptionName = "#{'nameExprSet'.concat('-sub')}")
+			Mono<Void> listenWithNameExpressionSet(String ignored) {
+				latchNameExprSet.countDown();
+				return Mono.empty();
+			}
+
+		}
+
+	}
+
+	@Nested
+	@ContextConfiguration(classes = WithNameGeneratorConfig.class)
+	class WithNameGenerator {
+
+		static final CountDownLatch latchNameGenWithNameSet = new CountDownLatch(1);
+		static final CountDownLatch latchNameGenOnly = new CountDownLatch(1);
+		static final CountDownLatch latchNameGenEmpty = new CountDownLatch(1);
+
+		@Autowired
+		protected ReactivePulsarListenerEndpointRegistry<String> registry;
+
+		@Test
+		void whenNameSetOnAnnotationThenSpecifiedNameTakesPrecedence() throws Exception {
+			assertSubscriptionName("nameGenWithNameSet-id").isEqualTo("nameGenWithNameSet-sub");
+			pulsarTemplate.send("nameGenWithNameSet-topic", "hello-nameGenWithNameSet");
+			assertThat(latchNameGenWithNameSet.await(5, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Test
+		void whenNameNotSetOnAnnotationThenGeneratedNameIsUsed() throws Exception {
+			assertSubscriptionName("nameGenOnly-id").isEqualTo("nameGenOnly-id-generated-sub");
+			pulsarTemplate.send("nameGenOnly-topic", "hello-nameGenOnly");
+			assertThat(latchNameGenOnly.await(5, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Test
+		void whenNameGeneratorReturnsEmptyThenDefaultGeneratedNameIsUsed() throws Exception {
+			assertSubscriptionName("nameGenEmpty-id")
+				.startsWith("org.springframework.Pulsar.ReactivePulsarListenerEndpointContainer#");
+			pulsarTemplate.send("nameGenEmpty-topic", "hello-nameGenEmpty");
+			assertThat(latchNameGenEmpty.await(5, TimeUnit.SECONDS)).isTrue();
+		}
+
+		private AbstractStringAssert<?> assertSubscriptionName(String containerId) {
+			return assertThat(registry.getListenerContainer(containerId).getContainerProperties())
+				.extracting(ReactivePulsarContainerProperties::getSubscriptionName, InstanceOfAssertFactories.STRING);
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		static class WithNameGeneratorConfig {
+
+			@ReactivePulsarListener(id = "nameGenWithNameSet-id", topics = "nameGenWithNameSet-topic",
+					subscriptionName = "nameGenWithNameSet-sub")
+			Mono<Void> listenWithGeneratorAndNameSet(String ignored) {
+				latchNameGenWithNameSet.countDown();
+				return Mono.empty();
+			}
+
+			@ReactivePulsarListener(id = "nameGenOnly-id", topics = "nameGenOnly-topic")
+			Mono<Void> listenWithGenerator(String ignored) {
+				latchNameGenOnly.countDown();
+				return Mono.empty();
+			}
+
+			@ReactivePulsarListener(id = "nameGenEmpty-id", topics = "nameGenEmpty-topic")
+			Mono<Void> listenWithGeneratorEmptyName(String ignored) {
+				latchNameGenEmpty.countDown();
+				return Mono.empty();
+			}
+
+			@Configuration(proxyBeanMethods = false)
+			static class NameGeneratorConfig {
+
+				@Bean
+				PulsarEndpointSubscriptionNameGenerator<ReactivePulsarListener> nameGenerator() {
+					return endpointSpecifier -> {
+						var listenerId = endpointSpecifier.id();
+						if ("nameGenEmpty-id".equals(listenerId)) {
+							return Optional.empty();
+						}
+						return Optional.of(listenerId + "-generated-sub");
+					};
+				}
+
+			}
+
+		}
+
+	}
+
+}

--- a/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/ReactivePulsarListenerTestsBase.java
+++ b/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/ReactivePulsarListenerTestsBase.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.reactive.listener;
+
+import java.util.List;
+
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.reactive.client.adapter.AdaptedReactivePulsarClientFactory;
+import org.apache.pulsar.reactive.client.api.ReactivePulsarClient;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.pulsar.core.DefaultPulsarClientFactory;
+import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
+import org.springframework.pulsar.core.PulsarAdministration;
+import org.springframework.pulsar.core.PulsarProducerFactory;
+import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.core.PulsarTopic;
+import org.springframework.pulsar.reactive.config.DefaultReactivePulsarListenerContainerFactory;
+import org.springframework.pulsar.reactive.config.ReactivePulsarListenerContainerFactory;
+import org.springframework.pulsar.reactive.config.annotation.EnableReactivePulsar;
+import org.springframework.pulsar.reactive.config.annotation.ReactivePulsarListener;
+import org.springframework.pulsar.reactive.core.DefaultReactivePulsarConsumerFactory;
+import org.springframework.pulsar.reactive.core.ReactiveMessageConsumerBuilderCustomizer;
+import org.springframework.pulsar.reactive.core.ReactivePulsarConsumerFactory;
+import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * Base implementation for {@link ReactivePulsarListener @ReactivePulsarListener} tests.
+ *
+ * @author Chris Bono
+ */
+@SpringJUnitConfig
+@DirtiesContext
+abstract class ReactivePulsarListenerTestsBase implements PulsarTestContainerSupport {
+
+	@Autowired
+	protected PulsarTemplate<String> pulsarTemplate;
+
+	@Autowired
+	protected PulsarClient pulsarClient;
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableReactivePulsar
+	static class TopLevelConfig {
+
+		@Bean
+		public PulsarProducerFactory<String> pulsarProducerFactory(PulsarClient pulsarClient) {
+			return new DefaultPulsarProducerFactory<>(pulsarClient);
+		}
+
+		@Bean
+		public PulsarClient pulsarClient() throws PulsarClientException {
+			return new DefaultPulsarClientFactory(PulsarTestContainerSupport.getPulsarBrokerUrl()).createClient();
+		}
+
+		@Bean
+		public ReactivePulsarClient pulsarReactivePulsarClient(PulsarClient pulsarClient) {
+			return AdaptedReactivePulsarClientFactory.create(pulsarClient);
+		}
+
+		@Bean
+		public PulsarTemplate<String> pulsarTemplate(PulsarProducerFactory<String> pulsarProducerFactory) {
+			return new PulsarTemplate<>(pulsarProducerFactory);
+		}
+
+		@Bean
+		public ReactivePulsarConsumerFactory<String> pulsarConsumerFactory(ReactivePulsarClient pulsarClient) {
+			return new DefaultReactivePulsarConsumerFactory<>(pulsarClient,
+					List.of((builder) -> builder.subscriptionInitialPosition(SubscriptionInitialPosition.Earliest)));
+		}
+
+		@Bean
+		ReactivePulsarListenerContainerFactory<String> reactivePulsarListenerContainerFactory(
+				ReactivePulsarConsumerFactory<String> pulsarConsumerFactory) {
+			return new DefaultReactivePulsarListenerContainerFactory<>(pulsarConsumerFactory,
+					new ReactivePulsarContainerProperties<>());
+		}
+
+		@Bean
+		PulsarAdministration pulsarAdministration() {
+			return new PulsarAdministration(PulsarTestContainerSupport.getHttpServiceUrl());
+		}
+
+		@Bean
+		PulsarTopic partitionedTopic() {
+			return PulsarTopic.builder("persistent://public/default/concurrency-on-pl").numberOfPartitions(3).build();
+		}
+
+		@Bean
+		ReactiveMessageConsumerBuilderCustomizer<?> subscriptionInitialPositionEarliest() {
+			return b -> b.subscriptionInitialPosition(SubscriptionInitialPosition.Earliest);
+		}
+
+	}
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
@@ -223,7 +223,7 @@ public class PulsarListenerAnnotationBeanPostProcessor<V> extends AbstractPulsar
 
 		endpoint.setBean(bean);
 		endpoint.setMessageHandlerMethodFactory(this.messageHandlerMethodFactory);
-		endpoint.setSubscriptionName(getEndpointSubscriptionName(pulsarListener));
+		resolveSubscriptionName(endpoint, pulsarListener);
 		endpoint.setId(getEndpointId(pulsarListener));
 		endpoint.setTopics(topics);
 		endpoint.setTopicPattern(topicPattern);
@@ -361,11 +361,9 @@ public class PulsarListenerAnnotationBeanPostProcessor<V> extends AbstractPulsar
 		}
 	}
 
-	private String getEndpointSubscriptionName(PulsarListener pulsarListener) {
-		if (StringUtils.hasText(pulsarListener.subscriptionName())) {
-			return resolveExpressionAsString(pulsarListener.subscriptionName(), "subscriptionName");
-		}
-		return GENERATED_ID_PREFIX + this.counter.getAndIncrement();
+	private void resolveSubscriptionName(MethodPulsarListenerEndpoint<?> endpoint, PulsarListener pulsarListener) {
+		endpoint.setSubscriptionName(determineEndpointSubscriptionName(pulsarListener,
+				pulsarListener.subscriptionName(), () -> GENERATED_ID_PREFIX + this.counter.getAndIncrement()));
 	}
 
 	private String getEndpointId(PulsarListener pulsarListener) {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/PulsarEndpointSubscriptionNameGenerator.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/PulsarEndpointSubscriptionNameGenerator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.config;
+
+import java.util.Optional;
+
+/**
+ * Contract to generate a subscription name for the Pulsar consumer endpoints.
+ *
+ * @param <T> the type of endpoint annotation - one of {@code PulsarListener} or
+ * {@code ReactivePulsarListener}
+ * @author Chris Bono
+ */
+public interface PulsarEndpointSubscriptionNameGenerator<T> {
+
+	/**
+	 * Generates a subscription name for the specified endpoint.
+	 * @param endpointSpecifier the annotation on the endpoint to generate the name for
+	 * @return the generated name or empty to have the container use its default name
+	 * generation strategy
+	 */
+	Optional<String> generateName(T endpointSpecifier);
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerSubscriptionNameTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerSubscriptionNameTests.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.pulsar.listener.PulsarListenerSubscriptionNameTests.WithNameGenerator.WithNameGeneratorConfig;
+import static org.springframework.pulsar.listener.PulsarListenerSubscriptionNameTests.WithoutNameGenerator.WithoutNameGeneratorConfig;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.pulsar.annotation.PulsarListener;
+import org.springframework.pulsar.config.PulsarEndpointSubscriptionNameGenerator;
+import org.springframework.pulsar.core.ConsumerBuilderCustomizer;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * Tests for the subscription name setting on the {@link PulsarListener @PulsarListener}.
+ *
+ * @author Chris Bono
+ */
+class PulsarListenerSubscriptionNameTests extends PulsarListenerTestsBase {
+
+	@Nested
+	@ContextConfiguration(classes = WithoutNameGeneratorConfig.class)
+	class WithoutNameGenerator {
+
+		static final CountDownLatch latchNameNotSet = new CountDownLatch(1);
+		static final CountDownLatch latchNameSet = new CountDownLatch(1);
+		static final CountDownLatch latchNameExprSet = new CountDownLatch(1);
+		static final CountDownLatch latchWithCustomizer = new CountDownLatch(1);
+
+		@Test
+		void whenNameNotSetOnAnnotationThenDefaultGeneratedNameIsUsed() throws Exception {
+			pulsarTemplate.send("nameNotSet-topic", "hello-nameNotSet");
+			assertThat(latchNameNotSet.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Test
+		void whenNameSetOnAnnotationThenSpecifiedNameIsUsed() throws Exception {
+			pulsarTemplate.send("nameSet-topic", "hello-nameSet");
+			assertThat(latchNameSet.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Test
+		void whenNameExprSetOnAnnotationThenEvaluatedNameIsUsed() throws Exception {
+			pulsarTemplate.send("nameExprSet-topic", "hello-nameExprSet");
+			assertThat(latchNameExprSet.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Test
+		void whenNameCustomizerIsConfiguredThenCustomizerTakesPrecedence() throws Exception {
+			pulsarTemplate.send("withCustomizer-topic", "hello-withCustomizer");
+			assertThat(latchWithCustomizer.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		static class WithoutNameGeneratorConfig {
+
+			@PulsarListener(topics = "nameNotSet-topic")
+			void listenWithoutNameSet(String ignored, Consumer<String> consumer) {
+				assertThat(consumer.getSubscription())
+					.startsWith("org.springframework.Pulsar.PulsarListenerEndpointContainer#");
+				latchNameNotSet.countDown();
+			}
+
+			@PulsarListener(topics = "nameSet-topic", subscriptionName = "nameSet-sub")
+			void listenWithNameSet(String ignored, Consumer<String> consumer) {
+				assertThat(consumer.getSubscription()).isEqualTo("nameSet-sub");
+				latchNameSet.countDown();
+			}
+
+			@PulsarListener(topics = "nameExprSet-topic", subscriptionName = "#{'nameExprSet'.concat('-sub')}")
+			void listenWithNameExpressionSet(String ignored, Consumer<String> consumer) {
+				assertThat(consumer.getSubscription()).isEqualTo("nameExprSet-sub");
+				latchNameExprSet.countDown();
+			}
+
+			@PulsarListener(topics = "withCustomizer-topic", subscriptionName = "withCustomizer-sub",
+					consumerCustomizer = "myCustomizer")
+			void listenWithCustomizer(String ignored, Consumer<String> consumer) {
+				assertThat(consumer.getSubscription()).isEqualTo("customizerSet-sub");
+				latchWithCustomizer.countDown();
+			}
+
+			@Bean
+			public ConsumerBuilderCustomizer<String> myCustomizer() {
+				return cb -> cb.subscriptionName("customizerSet-sub");
+			}
+
+		}
+
+	}
+
+	@Nested
+	@ContextConfiguration(classes = WithNameGeneratorConfig.class)
+	class WithNameGenerator {
+
+		static final CountDownLatch latchNameGenWithNameSet = new CountDownLatch(1);
+		static final CountDownLatch latchNameGenOnly = new CountDownLatch(1);
+		static final CountDownLatch latchNameGenEmpty = new CountDownLatch(1);
+
+		@Test
+		void whenNameSetOnAnnotationThenSpecifiedNameTakesPrecedence() throws Exception {
+			pulsarTemplate.send("nameGenWithNameSet-topic", "hello-nameGenWithNameSet");
+			assertThat(latchNameGenWithNameSet.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Test
+		void whenNameNotSetOnAnnotationThenGeneratedNameIsUsed() throws Exception {
+			pulsarTemplate.send("nameGenOnly-topic", "hello-nameGenOnly");
+			assertThat(latchNameGenOnly.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Test
+		void whenNameGeneratorReturnsEmptyThenDefaultGeneratedNameIsUsed() throws Exception {
+			pulsarTemplate.send("nameGenEmpty-topic", "hello-nameGenEmpty");
+			assertThat(latchNameGenEmpty.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		static class WithNameGeneratorConfig {
+
+			@PulsarListener(id = "5150", topics = "nameGenWithNameSet-topic",
+					subscriptionName = "nameGenWithNameSet-sub")
+			void listenWithGeneratorAndNameSet(String ignored, Consumer<String> consumer) {
+				assertThat(consumer.getSubscription()).isEqualTo("nameGenWithNameSet-sub");
+				latchNameGenWithNameSet.countDown();
+			}
+
+			@PulsarListener(id = "6160", topics = "nameGenOnly-topic")
+			void listenWithGenerator(String ignored, Consumer<String> consumer) {
+				assertThat(consumer.getSubscription()).isEqualTo("6160-sub");
+				latchNameGenOnly.countDown();
+			}
+
+			@PulsarListener(id = "7170", topics = "nameGenEmpty-topic")
+			void listenWithGeneratorEmptyName(String ignored, Consumer<String> consumer) {
+				assertThat(consumer.getSubscription())
+					.startsWith("org.springframework.Pulsar.PulsarListenerEndpointContainer#");
+				latchNameGenEmpty.countDown();
+			}
+
+			@Configuration(proxyBeanMethods = false)
+			static class NameGeneratorConfig {
+
+				@Bean
+				PulsarEndpointSubscriptionNameGenerator<PulsarListener> nameGenerator() {
+					return endpointSpecifier -> {
+						var listenerId = endpointSpecifier.id();
+						if ("7170".equals(listenerId)) {
+							return Optional.empty();
+						}
+						return Optional.of(listenerId + "-sub");
+					};
+				}
+
+			}
+
+		}
+
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTestsBase.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTestsBase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2022-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.listener;
+
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.pulsar.annotation.EnablePulsar;
+import org.springframework.pulsar.config.ConcurrentPulsarListenerContainerFactory;
+import org.springframework.pulsar.config.PulsarListenerContainerFactory;
+import org.springframework.pulsar.core.DefaultPulsarClientFactory;
+import org.springframework.pulsar.core.DefaultPulsarConsumerFactory;
+import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
+import org.springframework.pulsar.core.PulsarAdministration;
+import org.springframework.pulsar.core.PulsarConsumerFactory;
+import org.springframework.pulsar.core.PulsarProducerFactory;
+import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.core.PulsarTopic;
+import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Soby Chacko
+ * @author Alexander Preuß
+ * @author Chris Bono
+ */
+@SpringJUnitConfig
+@DirtiesContext
+abstract class PulsarListenerTestsBase implements PulsarTestContainerSupport {
+
+	@Autowired
+	protected PulsarTemplate<String> pulsarTemplate;
+
+	@Autowired
+	protected PulsarClient pulsarClient;
+
+	@Configuration(proxyBeanMethods = false)
+	@EnablePulsar
+	static class TopLevelConfig {
+
+		@Bean
+		PulsarProducerFactory<String> pulsarProducerFactory(PulsarClient pulsarClient) {
+			return new DefaultPulsarProducerFactory<>(pulsarClient, "foo-1");
+		}
+
+		@Bean
+		PulsarClient pulsarClient() throws PulsarClientException {
+			return new DefaultPulsarClientFactory(PulsarTestContainerSupport.getPulsarBrokerUrl()).createClient();
+		}
+
+		@Bean
+		PulsarTemplate<String> pulsarTemplate(PulsarProducerFactory<String> pulsarProducerFactory) {
+			return new PulsarTemplate<>(pulsarProducerFactory);
+		}
+
+		@Bean
+		PulsarConsumerFactory<?> pulsarConsumerFactory(PulsarClient pulsarClient) {
+			return new DefaultPulsarConsumerFactory<>(pulsarClient, null);
+		}
+
+		@Bean
+		PulsarListenerContainerFactory pulsarListenerContainerFactory(
+				PulsarConsumerFactory<Object> pulsarConsumerFactory) {
+			return new ConcurrentPulsarListenerContainerFactory<>(pulsarConsumerFactory,
+					new PulsarContainerProperties());
+		}
+
+		@Bean
+		PulsarAdministration pulsarAdministration() {
+			return new PulsarAdministration(PulsarTestContainerSupport.getHttpServiceUrl());
+		}
+
+		@Bean
+		PulsarTopic partitionedTopic() {
+			return PulsarTopic.builder("persistent://public/default/concurrency-on-pl").numberOfPartitions(3).build();
+		}
+
+	}
+
+}


### PR DESCRIPTION
This commit adds the ability to confgure a subscription name generator that will be used by `@PulsarListener` and `@ReactivePulsarListener` when no subscription name is specified.

See #480

Update to ref docs to follow in subsequent commit.

cc: @vpavic

<img width="622" alt="Screen Shot 2023-11-10 at 23 54 55" src="https://github.com/spring-projects/spring-pulsar/assets/28907971/68dd49a3-9858-45e0-9af2-3e526d8d2230">


<img width="622" alt="Screen Shot 2023-11-11 at 13 18 22" src="https://github.com/spring-projects/spring-pulsar/assets/28907971/b1889465-a4ff-4286-8e44-282b111ee0e5">
