### PR TITLE
Remove subscription type default from PulsarListener

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar.adoc
@@ -149,11 +149,15 @@ NOTE: If you are not using the starter, you will need to configure and register 
 When it comes to Pulsar consumers, we recommend that end-user applications use the `PulsarListener` annotation.
 To use `PulsarListener`, you need to use the `@EnablePulsar` annotation.
 When you use Spring Boot support, it automatically enables this annotation and configures all the components necessary for `PulsarListener`, such as the message listener infrastructure (which is responsible for creating the Pulsar consumer).
-`PulsarMessageListenerContainer` uses a `PulsarConsumerFactory` to create and manage the Pulsar consumer.
+`PulsarMessageListenerContainer` uses a `PulsarConsumerFactory` to create and manage the Pulsar consumer the underlying Pulsar consumer that it uses to consume messages.
 
-Spring Boot auto-configuration also provides this consumer factory which you can further configure by specifying **most** of the {spring-boot-pulsar-config-props}[`spring.pulsar.consumer.*`] application properties.
+Spring Boot provides this consumer factory which you can further configure by specifying the {spring-boot-pulsar-config-props}[`spring.pulsar.consumer.*`] application properties.
+**Most** of the configured properties on the factory will be respected in the listener with the following **exceptions**:
 
-NOTE: `spring.pulsar.consumer.subscription.name` is ignored and is instead generated when not specified on the annotation.
+TIP: The `spring.pulsar.consumer.subscription.name` property is ignored and is instead generated when not specified on the annotation.
+
+TIP: The `spring.pulsar.consumer.subscription-type` property is ignored and is instead taken from the value on the annotation. However, you can set the `subscriptionType = {}` on the annotation to instead use the property value as the default.
+
 
 Let us revisit the `PulsarListener` code snippet we saw in the quick-tour section:
 

--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/reactive-pulsar.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/reactive-pulsar.adoc
@@ -159,8 +159,8 @@ Mono<Void> listen(String message) {
 }
 ----
 
-In this most basic form, when the `subscriptionName` is not provided on the `@ReactivePulsarListener` annotation an auto-generated subscription name will be used.
-Likewise, when the `topics` are not directly provided, a <<topic-resolution-process-reactive,topic resolution process>> is used to determine the destination topic.
+In this most basic form, when the `topics` are not directly provided, a <<topic-resolution-process-reactive,topic resolution process>> is used to determine the destination topic.
+Likewise, when the `subscriptionName` is not provided on the `@ReactivePulsarListener` annotation an auto-generated subscription name will be used.
 
 In the `ReactivePulsarListener` method shown earlier, we receive the data as `String`, but we do not specify any schema types.
 Internally, the framework relies on Pulsar's schema mechanism to convert the data to the required type.
@@ -238,9 +238,14 @@ Flux<MessageResult<Void>> listen2(Flux<org.springframework.messaging.Message<Foo
 ----
 
 ==== Configuration - Application Properties
-The listener ultimately relies on `ReactivePulsarConsumerFactory` to create and manage the underlying Pulsar consumer.
+The listener relies on the `ReactivePulsarConsumerFactory` to create and manage the underlying Pulsar consumer that it uses to consume messages.
+Spring Boot provides this consumer factory which you can further configure by specifying the {spring-boot-pulsar-config-props}[`spring.pulsar.consumer.*`] application properties.
+**Most** of the configured properties on the factory will be respected in the listener with the following **exceptions**:
 
-Spring Boot provides this consumer factory which can be configured with any of the {spring-boot-pulsar-config-props}[`spring.pulsar.consumer.*`] application-properties.
+TIP: The `spring.pulsar.consumer.subscription.name` property is ignored and is instead generated when not specified on the annotation.
+
+TIP: The `spring.pulsar.consumer.subscription-type` property is ignored and is instead taken from the value on the annotation. However, you can set the `subscriptionType = {}` on the annotation to instead use the property value as the default.
+
 
 [[reactive-consumer-customizer]]
 ==== Consumer Customization

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListener.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListener.java
@@ -72,10 +72,12 @@ public @interface ReactivePulsarListener {
 	String subscriptionName() default "";
 
 	/**
-	 * Pulsar subscription type for this listener.
-	 * @return the {@code subscriptionType} for this listener
+	 * Pulsar subscription type for this listener - expected to be a single element array
+	 * with subscription type or empty array to indicate null type.
+	 * @return single element array with the subscription type or empty array to indicate
+	 * no type chosen by user
 	 */
-	SubscriptionType subscriptionType() default SubscriptionType.Exclusive;
+	SubscriptionType[] subscriptionType() default { SubscriptionType.Exclusive };
 
 	/**
 	 * Pulsar schema type for this listener.

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
@@ -153,7 +153,8 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V> extends Abstra
 					});
 			if (annotatedMethods.isEmpty()) {
 				this.nonAnnotatedClasses.add(bean.getClass());
-				this.logger.trace(() -> "No @PulsarListener annotations found on bean type: " + bean.getClass());
+				this.logger
+					.trace(() -> "No @ReactivePulsarListener annotations found on bean type: " + bean.getClass());
 			}
 			else {
 				// Non-empty set of methods
@@ -236,7 +237,7 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V> extends Abstra
 		endpoint.setId(getEndpointId(reactivePulsarListener));
 		endpoint.setTopics(topics);
 		endpoint.setTopicPattern(topicPattern);
-		endpoint.setSubscriptionType(reactivePulsarListener.subscriptionType());
+		resolveSubscriptionType(endpoint, reactivePulsarListener);
 		endpoint.setSchemaType(reactivePulsarListener.schemaType());
 
 		String concurrency = reactivePulsarListener.concurrency();
@@ -258,6 +259,15 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V> extends Abstra
 
 		resolveDeadLetterPolicy(endpoint, reactivePulsarListener);
 		resolveConsumerCustomizer(endpoint, reactivePulsarListener);
+	}
+
+	private void resolveSubscriptionType(MethodReactivePulsarListenerEndpoint<?> endpoint,
+			ReactivePulsarListener reactivePulsarListener) {
+		Assert.state(reactivePulsarListener.subscriptionType().length <= 1,
+				() -> "ReactivePulsarListener.subscriptionType must have 0 or 1 elements");
+		if (reactivePulsarListener.subscriptionType().length == 1) {
+			endpoint.setSubscriptionType(reactivePulsarListener.subscriptionType()[0]);
+		}
 	}
 
 	private void resolveDeadLetterPolicy(MethodReactivePulsarListenerEndpoint<?> endpoint,

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/ReactivePulsarContainerProperties.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/ReactivePulsarContainerProperties.java
@@ -43,7 +43,7 @@ public class ReactivePulsarContainerProperties<T> {
 
 	private String subscriptionName;
 
-	private SubscriptionType subscriptionType = SubscriptionType.Exclusive;
+	private SubscriptionType subscriptionType;
 
 	private Schema<T> schema;
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
@@ -74,10 +74,12 @@ public @interface PulsarListener {
 	String subscriptionName() default "";
 
 	/**
-	 * Pulsar subscription type for this listener.
-	 * @return the {@code subscriptionType} for this listener
+	 * Pulsar subscription type for this listener - expected to be a single element array
+	 * with subscription type or empty array to indicate null type.
+	 * @return single element array with the subscription type or empty array to indicate
+	 * no type chosen by user
 	 */
-	SubscriptionType subscriptionType() default SubscriptionType.Exclusive;
+	SubscriptionType[] subscriptionType() default { SubscriptionType.Exclusive };
 
 	/**
 	 * Pulsar schema type for this listener.
@@ -114,7 +116,7 @@ public @interface PulsarListener {
 	 * a {@link String}, in which case the {@link Boolean#parseBoolean(String)} is used to
 	 * obtain the value.
 	 * <p>
-	 * SpEL {@code #{...}} and property place holders {@code ${...}} are supported.
+	 * SpEL {@code #{...}} and property placeholders {@code ${...}} are supported.
 	 * @return true to auto start, false to not auto start.
 	 */
 	String autoStartup() default "";

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
@@ -226,7 +226,7 @@ public class PulsarListenerAnnotationBeanPostProcessor<V> extends AbstractPulsar
 		endpoint.setId(getEndpointId(pulsarListener));
 		endpoint.setTopics(topics);
 		endpoint.setTopicPattern(topicPattern);
-		endpoint.setSubscriptionType(pulsarListener.subscriptionType());
+		resolveSubscriptionType(endpoint, pulsarListener);
 		endpoint.setSchemaType(pulsarListener.schemaType());
 		endpoint.setAckMode(pulsarListener.ackMode());
 
@@ -248,6 +248,14 @@ public class PulsarListenerAnnotationBeanPostProcessor<V> extends AbstractPulsar
 		resolveDeadLetterPolicy(endpoint, pulsarListener);
 		resolvePulsarConsumerErrorHandler(endpoint, pulsarListener);
 		resolveConsumerCustomizer(endpoint, pulsarListener);
+	}
+
+	private void resolveSubscriptionType(MethodPulsarListenerEndpoint<?> endpoint, PulsarListener pulsarListener) {
+		Assert.state(pulsarListener.subscriptionType().length <= 1,
+				() -> "PulsarListener.subscriptionType must have 0 or 1 elements");
+		if (pulsarListener.subscriptionType().length == 1) {
+			endpoint.setSubscriptionType(pulsarListener.subscriptionType()[0]);
+		}
 	}
 
 	@SuppressWarnings({ "rawtypes" })

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
@@ -58,7 +58,7 @@ public class PulsarContainerProperties {
 
 	private String subscriptionName;
 
-	private SubscriptionType subscriptionType = SubscriptionType.Exclusive;
+	private SubscriptionType subscriptionType;
 
 	private Schema<?> schema;
 


### PR DESCRIPTION
This remove the default subscription type from `@PulsarListener` which then allows the defaults configured by `spring.pulsar.consumer.subscriptionType` to be respected. The Pulsar subscription type default is Exclusive (the previous default we had set in `@PulsarListener`) so if no value is set, ultimately `Exclusive` will still be used. 

See #488

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
