### PR TITLE
Fix authentication doc for OAuth2

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/authentication.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/authentication.adoc
@@ -75,7 +75,7 @@ spring:
   pulsar:
     client:
       authentication:
-        plugin-class-name: org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2
+        plugin-class-name: org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2
         param:
           issuerUrl: ...
           privateKey: ...


### PR DESCRIPTION
This commit fixes the name of the `pluginClassName` for the OAuth2 provider in authentication.adoc

See #500

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
