### PR TITLE
Add commons-compress 1.25.0 to buildSrc libs

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation localGroovy()
 	implementation buildLibs.asciidoc.gradle.jvm
 	implementation buildLibs.commons.codec
+	implementation buildLibs.commons.compress
 	implementation buildLibs.groovy.all
 	implementation buildLibs.jfrog.build.extractor.gradle
 	implementation buildLibs.jackson.databind

--- a/gradle/build-libs.versions.toml
+++ b/gradle/build-libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 asciidoc-gradle = "3.3.2"
 commons-codec = "1.16.0"
+commons-compress = "1.25.0"
 groovy = "2.5.17"
 jackson = "2.15.3"
 javaformat = "0.0.41"
@@ -17,6 +18,7 @@ version-catalog-update = "0.8.1"
 [libraries]
 asciidoc-gradle-jvm = { module = "org.asciidoctor:asciidoctor-gradle-jvm", version.ref = "asciidoc-gradle" }
 commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
+commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commons-compress" }
 groovy-all = { module = "org.codehaus.groovy:groovy-all", version.ref = "groovy" }
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }


### PR DESCRIPTION
This commit adds `org.apache.commmons:commons-compress:1.25.0` to the buildSrc dependencies to ensure the same version required by the Spring Boot plugin (1.25.0) is used.

See https://github.com/spring-projects/spring-boot/issues/39148#issuecomment-1919569616
<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
