### PR TITLE
PROTOTYPE: PulsarTestConsumer

### DIFF
--- a/spring-pulsar-test/spring-pulsar-test.gradle
+++ b/spring-pulsar-test/spring-pulsar-test.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'org.springframework.pulsar.spring-unpublished-module'
+	id 'org.springframework.pulsar.spring-unpublished-module'
+	id 'spring-pulsar.integration-test-conventions'
 }
 
 description = 'Spring Pulsar Test Module'
@@ -8,4 +9,6 @@ dependencies {
     implementation 'org.junit.jupiter:junit-jupiter-api'
     implementation 'org.testcontainers:pulsar'
     implementation 'org.testcontainers:junit-jupiter'
+	implementation project(':spring-pulsar')
+	testImplementation 'org.assertj:assertj-core'
 }

--- a/spring-pulsar-test/src/main/java/org/springframework/pulsar/test/support/PulsarTestConsumer.java
+++ b/spring-pulsar-test/src/main/java/org/springframework/pulsar/test/support/PulsarTestConsumer.java
@@ -1,0 +1,72 @@
+package org.springframework.pulsar.test.support;
+
+import static org.apache.pulsar.client.api.SubscriptionInitialPosition.Earliest;
+import static org.apache.pulsar.client.api.SubscriptionInitialPosition.Latest;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+
+import org.springframework.pulsar.core.DefaultPulsarConsumerFactory;
+
+public class PulsarTestConsumer {
+
+	private final DefaultPulsarConsumerFactory<?> consumerFactory;
+
+	private final Duration timeout;
+
+	public PulsarTestConsumer(DefaultPulsarConsumerFactory<?> consumerFactory, Duration timeout) {
+		this.consumerFactory = consumerFactory;
+		this.timeout = timeout;
+	}
+
+	public PulsarTestConsumer(DefaultPulsarConsumerFactory<?> consumerFactory) {
+		this(consumerFactory, Duration.ofSeconds(10));
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private <T> List<Message<T>> receiveEarliestMessages(int desiredMessageCount, List<String> topics, Schema<T> schema,
+			SubscriptionInitialPosition initialPosition, String subscriptionName) {
+		try (Consumer<T> consumer = consumerFactory.createConsumer((Schema) schema, topics, subscriptionName,
+				c -> c.subscriptionInitialPosition(initialPosition))) {
+			long remainingMillis = timeout.toMillis();
+			List<Message<T>> received = new ArrayList<>();
+			do {
+				try {
+					long loopStartTime = System.currentTimeMillis();
+					Message<T> receive = consumer.receive(Math.toIntExact(remainingMillis), TimeUnit.MILLISECONDS);
+					if (receive != null) {
+						received.add(receive);
+						consumer.acknowledge(receive);
+					}
+					remainingMillis -= System.currentTimeMillis() - loopStartTime;
+				}
+				catch (PulsarClientException e) {
+					throw new RuntimeException(e);
+				}
+			}
+			while (received.size() < desiredMessageCount && remainingMillis > 0);
+			return received;
+		}
+		catch (PulsarClientException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public <T> List<Message<T>> receiveEarliestMessages(int desiredMessageCount, List<String> topics,
+			Schema<T> schema) {
+		return receiveEarliestMessages(desiredMessageCount, topics, schema, Earliest, "test-subscription");
+	}
+
+	public <T> List<Message<T>> receiveLatestMessages(int desiredMessageCount, List<String> topics, Schema<T> schema) {
+		return receiveEarliestMessages(desiredMessageCount, topics, schema, Latest, "test-subscription");
+	}
+
+}

--- a/spring-pulsar-test/src/main/java/org/springframework/pulsar/test/support/PulsarTestContainerSupport.java
+++ b/spring-pulsar-test/src/main/java/org/springframework/pulsar/test/support/PulsarTestContainerSupport.java
@@ -18,6 +18,7 @@ package org.springframework.pulsar.test.support;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 

--- a/spring-pulsar-test/src/test/java/org/springframework/pulsar/test/support/PulsarTestConsumerTest.java
+++ b/spring-pulsar-test/src/test/java/org/springframework/pulsar/test/support/PulsarTestConsumerTest.java
@@ -1,0 +1,122 @@
+package org.springframework.pulsar.test.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.pulsar.core.DefaultPulsarConsumerFactory;
+import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
+import org.springframework.pulsar.core.PulsarTemplate;
+
+class PulsarTestConsumerTest implements PulsarTestContainerSupport {
+
+	private PulsarTestConsumer pulsarTestConsumer;
+
+	private PulsarTemplate<User> pulsarTemplate;
+
+	@BeforeEach
+	void pulsarTestConsumer() throws PulsarClientException {
+		var pulsarClient = PulsarClient.builder().serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl()).build();
+		var pulsarConsumerFactory = new DefaultPulsarConsumerFactory<>(pulsarClient, List.of());
+		this.pulsarTestConsumer = new PulsarTestConsumer(pulsarConsumerFactory, Duration.ofSeconds(5));
+		this.pulsarTemplate = new PulsarTemplate<>(new DefaultPulsarProducerFactory<>(pulsarClient));
+	}
+
+	@Nested
+	class ReceiveEarliestMessages {
+
+		@Test
+		void timeoutWithNoMessage() {
+			List<Message<User>> messages = pulsarTestConsumer.receiveEarliestMessages(1,
+					List.of("persistent://public/default/topic-1"), Schema.JSON(User.class));
+
+			assertThat(messages).isEmpty();
+		}
+
+		@Test
+		void timeoutWithLessThanExpectedMessages() {
+			pulsarTemplate.send("persistent://public/default/topic-2", new User("John"), Schema.JSON(User.class));
+
+			List<Message<User>> messages = pulsarTestConsumer.receiveEarliestMessages(5,
+					List.of("persistent://public/default/topic-2"), Schema.JSON(User.class));
+
+			assertThat(messages).hasSize(1)
+					.extracting(Message::getValue)
+					.containsExactly(new User("John"));
+		}
+
+		@Test
+		void onlyReceiveDesiredNumberOfMessages() {
+			IntStream.range(0, 10)
+				.forEach(i -> pulsarTemplate.send("persistent://public/default/topic-3", new User("John-" + i),
+						Schema.JSON(User.class)));
+
+			List<Message<User>> messages = pulsarTestConsumer.receiveEarliestMessages(5,
+					List.of("persistent://public/default/topic-3"), Schema.JSON(User.class));
+
+			assertThat(messages).hasSize(5)
+					.extracting(Message::getValue)
+					.containsExactly(new User("John-0"), new User("John-1"), new User("John-2"), new User("John-3"),
+							new User("John-4"));
+		}
+
+	}
+
+	@Nested
+	class ReceiveLatestMessages {
+
+		@Test
+		void timeoutWithNoMessage() {
+			List<Message<User>> messages = pulsarTestConsumer.receiveLatestMessages(1,
+					List.of("persistent://public/default/topic-4"), Schema.JSON(User.class));
+
+			assertThat(messages).isEmpty();
+		}
+
+		@Test
+		void timeoutWithLessThanExpectedMessages() {
+			IntStream.range(0, 10)
+					.forEach(i -> pulsarTemplate.send("persistent://public/default/topic-5", new User("John-" + i),
+							Schema.JSON(User.class)));
+			List<Message<User>> messages = pulsarTestConsumer.receiveEarliestMessages(5,
+					List.of("persistent://public/default/topic-5"), Schema.JSON(User.class));
+			assertThat(messages).hasSize(5);
+
+			messages = pulsarTestConsumer.receiveLatestMessages(15, List.of("persistent://public/default/topic-5"),
+					Schema.JSON(User.class));
+			assertThat(messages).hasSize(5)
+					.extracting(Message::getValue)
+					.containsExactly(new User("John-5"), new User("John-6"), new User("John-7"), new User("John-8"),
+							new User("John-9"));
+		}
+
+		@Test
+		void onlyReceiveDesiredNumberOfMessages() throws InterruptedException {
+			IntStream.range(0, 10)
+				.forEach(i -> pulsarTemplate.send("persistent://public/default/topic-6", new User("John-" + i),
+						Schema.JSON(User.class)));
+			List<Message<User>> messages = pulsarTestConsumer.receiveEarliestMessages(5,
+					List.of("persistent://public/default/topic-6"), Schema.JSON(User.class));
+			assertThat(messages).hasSize(5);
+
+			messages = pulsarTestConsumer.receiveLatestMessages(2, List.of("persistent://public/default/topic-6"),
+					Schema.JSON(User.class));
+
+			assertThat(messages)
+					.extracting(Message::getValue)
+					.containsExactly(new User("John-5"), new User("John-6"));
+		}
+
+	}
+
+}

--- a/spring-pulsar-test/src/test/java/org/springframework/pulsar/test/support/User.java
+++ b/spring-pulsar-test/src/test/java/org/springframework/pulsar/test/support/User.java
@@ -1,0 +1,4 @@
+package org.springframework.pulsar.test.support;
+
+public record User(String name) {
+}


### PR DESCRIPTION
Far from finished but wanted to get early feedback on my preliminary ideas.

I had to choose between letting `PulsarTestConsumer` work with `Consumer` directly and letting the user be responsible for creating the `Consumer` or let the framework manage the `Consumer` through `PulsarConsumerFactory`. 
I choose the later as it allows for a cleaner API more focused on what you actually want to get from the `PulsarTestConsumer`.