### PR TITLE
Remove Brave from Java Platform

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,5 @@
 [versions]
 # product
-brave = "6.0.1"
 caffeine = "3.1.8"
 jackson = "2.16.1"
 jsr305 = "3.0.2"
@@ -40,7 +39,6 @@ version-catalog-update = "0.8.4"
 
 [libraries]
 # Product libs
-brave-bom = { module = "io.zipkin.brave:brave-bom", version.ref = "brave" }
 caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson" }
 jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }

--- a/spring-pulsar-dependencies/spring-pulsar-dependencies.gradle
+++ b/spring-pulsar-dependencies/spring-pulsar-dependencies.gradle
@@ -12,7 +12,6 @@ dependencies {
 	api platform(libs.micrometer.bom)
 	api platform(libs.micrometer.tracing.bom)
 	api platform(libs.reactor.bom)
-	api platform(libs.brave.bom)
 	api platform(libs.assertj.bom)
 	api platform(libs.awaitility)
 	api platform(libs.junit.bom)

--- a/spring-pulsar-sample-apps/sample-failover-custom-router/build.gradle
+++ b/spring-pulsar-sample-apps/sample-failover-custom-router/build.gradle
@@ -21,10 +21,9 @@ ext['pulsar.version'] = "${pulsarVersion}"
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-pulsar'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-// TODO add back in once samples are not run during part of the 'test' target
-//	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
-//	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
-//	implementation 'io.zipkin.reporter2:zipkin-sender-urlconnection'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'io.zipkin.reporter2:zipkin-sender-urlconnection'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 
 	testImplementation project(':spring-pulsar-test')

--- a/spring-pulsar-sample-apps/sample-failover-custom-router/src/main/resources/application.yml
+++ b/spring-pulsar-sample-apps/sample-failover-custom-router/src/main/resources/application.yml
@@ -2,6 +2,10 @@ spring:
   pulsar:
     producer:
       message-routing-mode: custompartition
+    template:
+      observations-enabled: true
+    listener:
+      observation-enabled: true
   docker:
     compose:
       # when run from Intellij via "Run" button, path must be set from project root

--- a/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-app/build.gradle
+++ b/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-app/build.gradle
@@ -25,10 +25,6 @@ dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-pulsar"
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	implementation 'org.springframework.boot:spring-boot-starter-data-cassandra'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
-	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
-	implementation 'io.zipkin.reporter2:zipkin-sender-urlconnection'
 	implementation 'com.devskiller:jfairy:0.6.5'
 }
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
@@ -37,7 +37,6 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
 import org.springframework.pulsar.PulsarException;
-import org.springframework.pulsar.core.PulsarOperations.SendMessageBuilder;
 import org.springframework.pulsar.observation.DefaultPulsarTemplateObservationConvention;
 import org.springframework.pulsar.observation.PulsarMessageSenderContext;
 import org.springframework.pulsar.observation.PulsarTemplateObservation;


### PR DESCRIPTION
## Commit One

### Remove Brave from java platform
This commit removes Brave from being managed directly in the Java
Platform. Because the Brave version is already handled by Micrometer
Tracing BOM (which we import) there is no need to manage this
directly.

## Commit Two

### Add observations back in sample failover app
This commit adds back in the observation related dependencies into the
sample-failover-custom-router sample app. They were removed temporarily
as Spring Boot 3.3.0-SNAPSHOT had a bug when they bumped to Brave 6.0.1.

#### Additionally
* Add in template and listener observation-enabled properties as
Spring Boot is currently setting these to false byu default.

* Remove observation related dependencies from the sample functions app
as they were not intended to be there in the first place.