### PR TITLE
PORT "Add pulsar-client-reactive-api to spring-pulsar-reactive"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ micrometer-docs-gen = { module = "io.micrometer:micrometer-docs-generator", vers
 micrometer-tracing-bom = { module = "io.micrometer:micrometer-tracing-bom", version.ref = "micrometer-tracing" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
 pulsar-client-all = { module = "org.apache.pulsar:pulsar-client-all", version.ref = "pulsar" }
+pulsar-client-reactive-api = { module = "org.apache.pulsar:pulsar-client-reactive-api", version.ref = "pulsar-reactive" }
 pulsar-client-reactive-adapter = { module = "org.apache.pulsar:pulsar-client-reactive-adapter", version.ref = "pulsar-reactive" }
 pulsar-client-reactive-producer-cache-caffeine-shaded = { module = "org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine-shaded", version.ref = "pulsar-reactive" }
 reactor-bom = { module = "io.projectreactor:reactor-bom", version.ref = "reactor" }

--- a/spring-pulsar-reactive/spring-pulsar-reactive.gradle
+++ b/spring-pulsar-reactive/spring-pulsar-reactive.gradle
@@ -6,9 +6,16 @@ description = 'Spring Pulsar Reactive Support'
 
 dependencies {
 	api project (':spring-pulsar')
+	api (libs.pulsar.client.reactive.api) {
+		// spring-pulsar includes a pulsar-client-api with its unwanted transitive deps excluded
+		exclude group: "org.apache.pulsar", module: "pulsar-client-api"
+	}
 	api (libs.pulsar.client.reactive.adapter) {
 		// spring-pulsar includes a pulsar-client with its unwanted transitive deps excluded
 		exclude group: "org.apache.pulsar", module: "pulsar-client"
+		// (above) we include a pulsar-client-reactive-api whose pulsar-client-api with
+		// unwanted transitive deps excluded
+		exclude group: "org.apache.pulsar", module: "pulsar-client-reactive-api"
 	}
 	api(libs.pulsar.client.reactive.producer.cache.caffeine.shaded) {
 		// (above) we include a pulsar-client-reactive-adapter whose pulsar-client with


### PR DESCRIPTION
The pulsar-client-reactive-api transitively includes the pulsar-client-api. To insulate against different Pulsar client versions in the Pulsar Reactive Client and Spring Pulsar we exclude this transitive dependency and then include the version dictated by Spring Pulsar. This is the same technique that is already done for the pulsar-client-reactive-adapter.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
