### PR TITLE
Override commons-compress version to 1.26.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # product
 caffeine = "3.1.8"
-commons-compress = "1.26.0"
+commons-compress = "1.26.1"
 jackson = "2.17.0"
 jsr305 = "3.0.2"
 logback = "1.4.14"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 # product
 caffeine = "3.1.8"
+commons-compress = "1.26.0"
 jackson = "2.17.0"
 jsr305 = "3.0.2"
 logback = "1.4.14"
@@ -57,6 +58,7 @@ spring-retry = { module = "org.springframework.retry:spring-retry", version.ref 
 # Testing libs
 assertj-bom = { module = "org.assertj:assertj-bom", version.ref = "assertj" }
 awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
+commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "commons-compress" }
 json-path = { module = "com.jayway.jsonpath:json-path", version.ref = "json-path" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }

--- a/spring-pulsar-test/spring-pulsar-test.gradle
+++ b/spring-pulsar-test/spring-pulsar-test.gradle
@@ -6,8 +6,16 @@ description = 'Spring Pulsar Test Utilities Module'
 
 dependencies {
     implementation 'org.junit.jupiter:junit-jupiter-api'
-    implementation 'org.testcontainers:pulsar'
-    implementation 'org.testcontainers:junit-jupiter'
+	// Testcontainers brings in commons-compress 1.24.0 which has 2 CVEs.
+	// Exclude and override version to 1.26.0 until TC updates to latest
+	// commons-compress.
+    implementation('org.testcontainers:pulsar') {
+		exclude group: 'org.apache.commons', module: 'commons-compress'
+	}
+    implementation('org.testcontainers:junit-jupiter') {
+		exclude group: 'org.apache.commons', module: 'commons-compress'
+	}
+	implementation libs.commons.compress
     implementation project(':spring-pulsar')
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'


### PR DESCRIPTION
The `spring-pulsar-test` module has a dependency on `org.testcontainers:testcontainers:1.19.7` which transitively brings in `org.apache.commons:commons-compress:1.24.0` with its 2 CVEs.

In order to rid the `spring-pulsar-test` module from these piggy-backed CVEs, this commit excludes `commons-compress` from the testcontainers dependencies and includes `commons-compress:1.26.1`.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
