### PR TITLE
Add support for bean customizers

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/BeanCustomizer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/BeanCustomizer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.annotation;
+
+/**
+ * Customize a bean.
+ *
+ * @param <B> the bean type to customize
+ * @author Chris Bono
+ */
+@FunctionalInterface
+public interface BeanCustomizer<B> {
+
+	/**
+	 * Customize the bean.
+	 * @param bean the bean to customize
+	 */
+	void customize(B bean);
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/BeanCustomizerPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/BeanCustomizerPostProcessor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.annotation;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * A {@link BeanPostProcessor} that applies a customizer to beans of a specified type.
+ * <p>
+ * There must be only one customizer in the application context in order for it to be
+ * applied.
+ *
+ * @param <B> the type of bean to customize
+ * @param <C> the type of customizer
+ * @author Chris Bono
+ */
+class BeanCustomizerPostProcessor<B, C extends BeanCustomizer<B>>
+		implements BeanPostProcessor, ApplicationContextAware {
+
+	private final LogAccessor logger = new LogAccessor(getClass());
+
+	private final Class<B> beanType;
+
+	private final Class<C> customizerType;
+
+	private ApplicationContext applicationContext;
+
+	BeanCustomizerPostProcessor(Class<B> beanType, Class<C> customizerType) {
+		this.beanType = beanType;
+		this.customizerType = customizerType;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+		if (this.beanType.isInstance(bean)) {
+			B typedBean = this.beanType.cast(bean);
+			var customizers = this.applicationContext.getBeansOfType(this.customizerType);
+			if (CollectionUtils.isEmpty(customizers)) {
+				return bean;
+			}
+			if (customizers.size() > 1) {
+				this.logger.warn("Found multiple %s beans [%s] - must be only 1 in order to apply"
+					.formatted(this.customizerType.getSimpleName(), customizers.keySet()));
+			}
+			else {
+				customizers.values().stream().forEach((c) -> c.customize(typedBean));
+			}
+		}
+		return bean;
+	}
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactoryCustomizer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactoryCustomizer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.config;
+
+import org.springframework.pulsar.annotation.BeanCustomizer;
+
+/**
+ * Callback interface that can be implemented to customize a
+ * {@link ConcurrentPulsarListenerContainerFactory}.
+ *
+ * @param <T> The message payload type
+ * @author Chris Bono
+ */
+public interface ConcurrentPulsarListenerContainerFactoryCustomizer<T>
+		extends BeanCustomizer<ConcurrentPulsarListenerContainerFactory<T>> {
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplateCustomizer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplateCustomizer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.core;
+
+import org.springframework.pulsar.annotation.BeanCustomizer;
+
+/**
+ * Callback interface that can be implemented to customize a {@link PulsarTemplate}.
+ *
+ * @param <T> the payload type of the template
+ * @author Chris Bono
+ */
+public interface PulsarTemplateCustomizer<T> extends BeanCustomizer<PulsarTemplate<T>> {
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarListenerContainerFactoryCustomizerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarListenerContainerFactoryCustomizerTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.pulsar.annotation.EnablePulsar;
+import org.springframework.pulsar.config.ConcurrentPulsarListenerContainerFactory;
+import org.springframework.pulsar.config.ConcurrentPulsarListenerContainerFactoryCustomizer;
+
+/**
+ * Tests for applying {@link ConcurrentPulsarListenerContainerFactoryCustomizer} to the
+ * {@link ConcurrentPulsarListenerContainerFactory}.
+ *
+ * @author Chris Bono
+ */
+class ConcurrentPulsarListenerContainerFactoryCustomizerTests {
+
+	@Test
+	void whenSingleCustomizerAvailableThenItIsApplied() {
+		var containerFactory = mock(ConcurrentPulsarListenerContainerFactory.class);
+		var containerProps = new PulsarContainerProperties();
+		when(containerFactory.getContainerProperties()).thenReturn(containerProps);
+		ConcurrentPulsarListenerContainerFactoryCustomizer<?> customizer = (
+				cf) -> cf.getContainerProperties().transactions().setTimeout(Duration.ofSeconds(45));
+		try (var appContext = new AnnotationConfigApplicationContext()) {
+			appContext.registerBean(ConcurrentPulsarListenerContainerFactory.class, () -> containerFactory);
+			appContext.registerBean(ConcurrentPulsarListenerContainerFactoryCustomizer.class, () -> customizer);
+			appContext.register(ConcurrentPulsarListenerContainerFactoryCustomizerTestsConfig.class);
+			appContext.refresh();
+			assertThat(containerProps.transactions().getTimeout()).isEqualTo(Duration.ofSeconds(45));
+		}
+	}
+
+	@Test
+	void whenMultipleCustomizersAvailableThenNoneAreApplied() {
+		var containerFactory = mock(ConcurrentPulsarListenerContainerFactory.class);
+		var containerProps = new PulsarContainerProperties();
+		when(containerFactory.getContainerProperties()).thenReturn(containerProps);
+		ConcurrentPulsarListenerContainerFactoryCustomizer<?> customizer1 = (
+				cf) -> cf.getContainerProperties().transactions().setTimeout(Duration.ofSeconds(45));
+		ConcurrentPulsarListenerContainerFactoryCustomizer<?> customizer2 = (
+				cf) -> cf.getContainerProperties().transactions().setTimeout(Duration.ofSeconds(60));
+		try (var appContext = new AnnotationConfigApplicationContext()) {
+			appContext.registerBean(ConcurrentPulsarListenerContainerFactory.class, () -> containerFactory);
+			appContext.registerBean("customizer1", ConcurrentPulsarListenerContainerFactoryCustomizer.class,
+					() -> customizer1);
+			appContext.registerBean("customizer2", ConcurrentPulsarListenerContainerFactoryCustomizer.class,
+					() -> customizer2);
+			appContext.register(ConcurrentPulsarListenerContainerFactoryCustomizerTestsConfig.class);
+			appContext.refresh();
+			assertThat(containerProps.transactions().getTimeout()).isNull();
+		}
+	}
+
+	@Test
+	void whenNoCustomizersAvaiableThenContextStartsWithoutFailure() {
+		var containerFactory = mock(ConcurrentPulsarListenerContainerFactory.class);
+		try (var appContext = new AnnotationConfigApplicationContext()) {
+			appContext.registerBean(ConcurrentPulsarListenerContainerFactory.class, () -> containerFactory);
+			appContext.register(ConcurrentPulsarListenerContainerFactoryCustomizerTestsConfig.class);
+			appContext.refresh();
+		}
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnablePulsar
+	static class ConcurrentPulsarListenerContainerFactoryCustomizerTestsConfig {
+
+	}
+
+}


### PR DESCRIPTION
This commit adds the notion of `BeanCustomizer` and a generic bean post processor that will apply any unique customizer to its target bean.

Included are concrete customizers for PulsarTemplate and ConcurrentPulsarListenerContainerFactory in order to make it easier to configure transactions to these components.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
