### PR TITLE
Add test for Pulsar synchronized transactions

### DIFF
--- a/spring-pulsar/spring-pulsar.gradle
+++ b/spring-pulsar/spring-pulsar.gradle
@@ -29,9 +29,6 @@ dependencies {
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-joda'
 
 	testImplementation project(':spring-pulsar-test')
-	testImplementation 'org.springframework:spring-jdbc'
-	testImplementation "org.testcontainers:mysql"
-	testImplementation 'mysql:mysql-connector-java:8.0.33'
 	testImplementation 'io.micrometer:micrometer-observation-test'
 	testImplementation 'io.micrometer:micrometer-tracing-bridge-brave'
 	testImplementation 'io.micrometer:micrometer-tracing-test'
@@ -48,4 +45,10 @@ dependencies {
 	// Output capture used by PulsarFunctionAdministrationTests
 	testImplementation libs.system.lambda
 	testRuntimeOnly libs.logback.classic
+
+	// Used by PulsarMixedTransactionTests (Pulsar + DB)
+	testImplementation 'org.springframework:spring-jdbc'
+	testImplementation "org.testcontainers:mysql"
+	testImplementation 'mysql:mysql-connector-java:8.0.33'
+
 }

--- a/spring-pulsar/spring-pulsar.gradle
+++ b/spring-pulsar/spring-pulsar.gradle
@@ -29,6 +29,9 @@ dependencies {
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-joda'
 
 	testImplementation project(':spring-pulsar-test')
+	testImplementation 'org.springframework:spring-jdbc'
+	testImplementation "org.testcontainers:mysql"
+	testImplementation 'mysql:mysql-connector-java:8.0.33'
 	testImplementation 'io.micrometer:micrometer-observation-test'
 	testImplementation 'io.micrometer:micrometer-tracing-bridge-brave'
 	testImplementation 'io.micrometer:micrometer-tracing-test'

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/transaction/PulsarMixedTransactionTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/transaction/PulsarMixedTransactionTests.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.transaction;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.pulsar.PulsarException;
+import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.transaction.PulsarMixedTransactionTests.PulsarProducerWithDbTransaction.PulsarProducerWithDbTransactionConfig;
+import org.springframework.pulsar.transaction.PulsarMixedTransactionTests.PulsarProducerWithDbTransaction.PulsarProducerWithDbTransactionConfig.ProducerOnlyService;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.interceptor.TransactionAspectSupport;
+
+/**
+ * Tests for Pulsar transaction support with other resource transactions.
+ *
+ * @author Chris Bono
+ */
+class PulsarMixedTransactionTests extends PulsarTxnWithDbTxnTestsBase {
+
+	@Nested
+	@ContextConfiguration(classes = PulsarProducerWithDbTransactionConfig.class)
+	class PulsarProducerWithDbTransaction {
+
+		static final String topic = "ppwdbt-topic";
+
+		@Test
+		void whenDbTxnIsCommittedThenMessagesAreCommitted(@Autowired ProducerOnlyService producerService) {
+			var thing1 = new Thing(1L, "msg1");
+			producerService.handleRequest(thing1, false, false);
+			assertThatMessagesAreInTopic(topic, thing1.name());
+			assertThatMessagesAreInDb(thing1);
+		}
+
+		@Test
+		void whenDbTxnIsSetRollbackOnlyThenMessagesAreNotCommitted(@Autowired ProducerOnlyService producerService) {
+			var thing2 = new Thing(2L, "msg2");
+			producerService.handleRequest(thing2, true, false);
+			assertThatMessagesAreNotInTopic(topic, thing2.name());
+			assertThatMessagesAreNotInDb(thing2);
+		}
+
+		@Test
+		void whenServiceThrowsExceptionThenMessagesAreNotCommitted(@Autowired ProducerOnlyService producerService) {
+			var thing3 = new Thing(3L, "msg3");
+			assertThatExceptionOfType(PulsarException.class)
+				.isThrownBy(() -> producerService.handleRequest(thing3, false, true))
+				.withMessage("Failed to commit due to chaos");
+			assertThatMessagesAreNotInTopic(topic, thing3.name());
+			assertThatMessagesAreNotInDb(thing3);
+		}
+
+		@EnableTransactionManagement
+		@Configuration
+		static class PulsarProducerWithDbTransactionConfig {
+
+			@Service
+			class ProducerOnlyService {
+
+				@Autowired
+				private JdbcTemplate jdbcTemplate;
+
+				@Autowired
+				private PulsarTemplate<String> transactionalPulsarTemplate;
+
+				@Transactional("dataSourceTransactionManager")
+				public void handleRequest(Thing thing, boolean setRollbackOnly, boolean throwPulsarException) {
+					PulsarTxnWithDbTxnTestsBase.insertThingIntoDb(jdbcTemplate, thing);
+					this.transactionalPulsarTemplate.send(topic, thing.name());
+					if (setRollbackOnly) {
+						TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
+					}
+					if (throwPulsarException) {
+						throw new PulsarException("Failed to commit due to chaos");
+					}
+				}
+
+			}
+
+		}
+
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/transaction/PulsarTxnTestsBase.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/transaction/PulsarTxnTestsBase.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.ObjectAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.pulsar.annotation.EnablePulsar;
+import org.springframework.pulsar.config.ConcurrentPulsarListenerContainerFactory;
+import org.springframework.pulsar.config.PulsarListenerContainerFactory;
+import org.springframework.pulsar.core.ConsumerBuilderCustomizer;
+import org.springframework.pulsar.core.DefaultPulsarClientFactory;
+import org.springframework.pulsar.core.DefaultPulsarConsumerFactory;
+import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
+import org.springframework.pulsar.core.PulsarAdministration;
+import org.springframework.pulsar.core.PulsarConsumerFactory;
+import org.springframework.pulsar.core.PulsarProducerFactory;
+import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.listener.PulsarContainerProperties;
+import org.springframework.pulsar.test.support.PulsarConsumerTestUtil;
+import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * Provides base support for tests that use Pulsar transactions.
+ *
+ * @author Chris Bono
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@Testcontainers(disabledWithoutDocker = true)
+class PulsarTxnTestsBase {
+
+	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage())
+		.withTransactions();
+
+	@BeforeAll
+	static void startPulsarContainer() {
+		PULSAR_CONTAINER.start();
+	}
+
+	@Autowired
+	protected PulsarClient pulsarClient;
+
+	@Autowired
+	protected PulsarTemplate<String> transactionalPulsarTemplate;
+
+	protected void assertThatMessagesAreInTopic(String topicOut, String... expectedMessages) {
+		assertMessagesInTopic(topicOut).contains(expectedMessages);
+	}
+
+	protected void assertThatMessagesAreNotInTopic(String topicOut, String... notExpectedMessages) {
+		assertMessagesInTopic(topicOut).doesNotContain(notExpectedMessages);
+	}
+
+	protected AbstractListAssert<?, List<? extends String>, String, ObjectAssert<String>> assertMessagesInTopic(
+			String topic) {
+		return assertThat(PulsarConsumerTestUtil.<String>consumeMessages(pulsarClient)
+			.fromTopic(topic)
+			.withSchema(Schema.STRING)
+			.awaitAtMost(Duration.ofSeconds(5))
+			.get()).map(Message::getValue);
+	}
+
+	@Configuration
+	@EnablePulsar
+	static class TopLevelConfig {
+
+		@Bean
+		PulsarProducerFactory<String> pulsarProducerFactory(PulsarClient pulsarClient) {
+			return new DefaultPulsarProducerFactory<>(pulsarClient, "foo-1");
+		}
+
+		@Bean
+		PulsarClient pulsarClient() {
+			return new DefaultPulsarClientFactory((clientBuilder) -> {
+				clientBuilder.serviceUrl(PULSAR_CONTAINER.getPulsarBrokerUrl());
+				clientBuilder.enableTransaction(true);
+			}).createClient();
+		}
+
+		@Bean
+		PulsarTemplate<String> transactionalPulsarTemplate(PulsarProducerFactory<String> pulsarProducerFactory) {
+			var template = new PulsarTemplate<>(pulsarProducerFactory);
+			template.transactions().setEnabled(true);
+			return template;
+		}
+
+		@Bean
+		public PulsarConsumerFactory<?> pulsarConsumerFactory(PulsarClient pulsarClient,
+				ObjectProvider<ConsumerBuilderCustomizer<String>> defaultConsumerCustomizersProvider) {
+			return new DefaultPulsarConsumerFactory<>(pulsarClient,
+					defaultConsumerCustomizersProvider.orderedStream().toList());
+		}
+
+		@Bean
+		PulsarContainerProperties pulsarContainerProperties(PulsarAwareTransactionManager pulsarTransactionManager) {
+			var containerProps = new PulsarContainerProperties();
+			containerProps.transactions().setEnabled(true);
+			containerProps.transactions().setRequired(false);
+			containerProps.transactions().setTransactionManager(pulsarTransactionManager);
+			return containerProps;
+		}
+
+		@Bean
+		PulsarListenerContainerFactory pulsarListenerContainerFactory(
+				PulsarConsumerFactory<Object> pulsarConsumerFactory, PulsarContainerProperties pulsarContainerProps) {
+			return new ConcurrentPulsarListenerContainerFactory<>(pulsarConsumerFactory, pulsarContainerProps);
+		}
+
+		@Bean
+		PulsarAdministration pulsarAdministration() {
+			return new PulsarAdministration(PULSAR_CONTAINER.getHttpServiceUrl());
+		}
+
+		@Bean
+		PulsarAwareTransactionManager pulsarTransactionManager(PulsarClient pulsarClient) {
+			return new PulsarTransactionManager(pulsarClient);
+		}
+
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/transaction/PulsarTxnWithDbTxnTestsBase.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/transaction/PulsarTxnWithDbTxnTestsBase.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.transaction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.assertj.core.api.ListAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.transaction.annotation.TransactionManagementConfigurer;
+
+/**
+ * Provides base support for tests that use Pulsar transactions mixed with DB
+ * transactions.
+ *
+ * @author Chris Bono
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@Testcontainers(disabledWithoutDocker = true)
+class PulsarTxnWithDbTxnTestsBase extends PulsarTxnTestsBase {
+
+	private static final Logger LOG = LoggerFactory.getLogger(PulsarTxnWithDbTxnTestsBase.class);
+
+	static MySQLContainer<?> MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:latest"))
+		.withInitScript("transaction/init.sql")
+		.withLogConsumer(new Slf4jLogConsumer(LOG));
+
+	@BeforeAll
+	static void startMySqlContainer() {
+		MYSQL_CONTAINER.start();
+	}
+
+	@Autowired
+	protected JdbcTemplate jdbcTemplate;
+
+	protected void assertThatMessagesAreInDb(Thing... expectedMessages) {
+		assertThatMessagesInDb().contains(expectedMessages);
+	}
+
+	protected void assertThatMessagesAreNotInDb(Thing... notExpectedMessages) {
+		assertThatMessagesInDb().doesNotContain(notExpectedMessages);
+	}
+
+	protected ListAssert<Thing> assertThatMessagesInDb() {
+		List<Thing> things = this.jdbcTemplate.query("select * from thing",
+				(rs, rowNum) -> new Thing(rs.getLong(1), rs.getString(2)));
+		return assertThat(things);
+	}
+
+	protected static void insertThingIntoDb(JdbcTemplate jdbcTemplate, Thing thing) {
+		jdbcTemplate.update("insert into thing (id, name) values (?, ?)", thing.id(), thing.name());
+	}
+
+	@Configuration
+	static class TopLevelConfig implements TransactionManagementConfigurer {
+
+		@Bean
+		DataSource dataSource() {
+			DriverManagerDataSource dataSource = new DriverManagerDataSource();
+			dataSource.setDriverClassName(MYSQL_CONTAINER.getDriverClassName());
+			dataSource.setUrl(MYSQL_CONTAINER.getJdbcUrl());
+			dataSource.setUsername(MYSQL_CONTAINER.getUsername());
+			dataSource.setPassword(MYSQL_CONTAINER.getPassword());
+			return dataSource;
+		}
+
+		@Bean
+		JdbcTemplate jdbcTemplate(DataSource dataSource) {
+			return new JdbcTemplate(dataSource);
+		}
+
+		@Bean
+		public DataSourceTransactionManager dataSourceTransactionManager() {
+			return new DataSourceTransactionManager(dataSource());
+		}
+
+		@Override
+		public DataSourceTransactionManager annotationDrivenTransactionManager() {
+			return dataSourceTransactionManager();
+		}
+
+	}
+
+	public record Thing(Long id, String name) {
+	}
+
+}

--- a/spring-pulsar/src/test/resources/transaction/init.sql
+++ b/spring-pulsar/src/test/resources/transaction/init.sql
@@ -1,0 +1,5 @@
+create table thing (
+    id bigint not null,
+    name varchar(255),
+    primary key (id)
+);


### PR DESCRIPTION
* Adds tests for using a transactional PulsarTemplate from within a `@Transactional` service method. The test sends a message to Pulsar and inserts a row in DB and does some form of rollback (or not) to make sure things are as expected.

See #661

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
