### PR TITLE
Fix payload type in Reactive tombstone doc

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/reactive-pulsar/reactive-message-consumption.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/reactive-pulsar/reactive-message-consumption.adoc
@@ -112,6 +112,8 @@ Flux<MessageResult<Void>> listen2(Flux<org.springframework.messaging.Message<Foo
 NOTE: The listener method returns a `Flux<MessageResult<Void>>` where each element represents a processed message and holds the message id, value and whether it was acknowledged.
 The Spring `MessageUtils` has a set of static factory methods that can be used to create the appropriate `MessageResult` instance from a Spring message.
 
+NOTE: There is no support for using `org.apache.pulsar.client.api.Messages<T>` in a `@ReactivePulsarListener`
+
 === Configuration - Application Properties
 The listener relies on the `ReactivePulsarConsumerFactory` to create and manage the underlying Pulsar consumer that it uses to consume messages.
 Spring Boot provides this consumer factory which you can further configure by specifying the {spring-boot-pulsar-config-props}[`spring.pulsar.consumer.*`] application properties.

--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/tombstones-reactive.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/tombstones-reactive.adoc
@@ -36,7 +36,7 @@ For `@ReactivePularListener`, the `null` payload is passed into the listener met
 | `Flux<org.apache.pulsar.client.api.Message<T>>`
 | non-null flux whose entries are non-null Pulsar messages whose `getValue()` returns `null`
 
-| `Flux<org.apache.pulsar.client.api.Messages<T>>`
+| `Flux<org.springframework.messaging.Message<T>>`
 | non-null flux whose entries are non-null Spring messages whose `getPayload()` returns `PulsarNull`
 
 |===


### PR DESCRIPTION
Also clarify that `org.apache.pulsar.client.api.Messages<T>` are not supported in `@ReactivePulsarListener`.

Fixes #667

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
