### PR TITLE
enable the use of a custom ObjectMapper

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/MethodReactivePulsarListenerEndpoint.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/MethodReactivePulsarListenerEndpoint.java
@@ -53,6 +53,7 @@ import org.springframework.pulsar.support.converter.PulsarMessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import reactor.core.publisher.Flux;
 
 /**
@@ -70,6 +71,8 @@ public class MethodReactivePulsarListenerEndpoint<V> extends AbstractReactivePul
 	private Object bean;
 
 	private Method method;
+
+	private ObjectMapper objectMapper;
 
 	private MessageHandlerMethodFactory messageHandlerMethodFactory;
 
@@ -212,10 +215,12 @@ public class MethodReactivePulsarListenerEndpoint<V> extends AbstractReactivePul
 
 		AbstractPulsarMessageToSpringMessageAdapter<V> listener;
 		if (isFluxListener()) {
-			listener = new PulsarReactiveStreamingMessagingMessageListenerAdapter<>(this.bean, this.method);
+			listener = new PulsarReactiveStreamingMessagingMessageListenerAdapter<>(this.bean, this.method,
+					this.objectMapper);
 		}
 		else {
-			listener = new PulsarReactiveOneByOneMessagingMessageListenerAdapter<>(this.bean, this.method);
+			listener = new PulsarReactiveOneByOneMessagingMessageListenerAdapter<>(this.bean, this.method,
+					this.objectMapper);
 		}
 
 		if (messageConverter instanceof PulsarMessageConverter) {

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveMessagingMessageListenerAdapter.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveMessagingMessageListenerAdapter.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.api.Messages;
 import org.springframework.pulsar.listener.adapter.AbstractPulsarMessageToSpringMessageAdapter;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarMessageHandler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import reactor.core.publisher.Flux;
 
 /**
@@ -36,8 +37,8 @@ import reactor.core.publisher.Flux;
 public abstract class PulsarReactiveMessagingMessageListenerAdapter<V>
 		extends AbstractPulsarMessageToSpringMessageAdapter<V> {
 
-	public PulsarReactiveMessagingMessageListenerAdapter(Object bean, Method method) {
-		super(bean, method);
+	public PulsarReactiveMessagingMessageListenerAdapter(Object bean, Method method, ObjectMapper objectMapper) {
+		super(bean, method, objectMapper);
 	}
 
 	/**

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveOneByOneMessagingMessageListenerAdapter.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveOneByOneMessagingMessageListenerAdapter.java
@@ -25,6 +25,7 @@ import org.springframework.pulsar.listener.adapter.HandlerAdapter;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarMessageHandler;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarOneByOneMessageHandler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import reactor.core.publisher.Mono;
 
 /**
@@ -39,8 +40,9 @@ import reactor.core.publisher.Mono;
 public class PulsarReactiveOneByOneMessagingMessageListenerAdapter<V>
 		extends PulsarReactiveMessagingMessageListenerAdapter<V> implements ReactivePulsarOneByOneMessageHandler<V> {
 
-	public PulsarReactiveOneByOneMessagingMessageListenerAdapter(Object bean, Method method) {
-		super(bean, method);
+	public PulsarReactiveOneByOneMessagingMessageListenerAdapter(Object bean, Method method,
+			ObjectMapper objectMapper) {
+		super(bean, method, objectMapper);
 	}
 
 	@Override

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveStreamingMessagingMessageListenerAdapter.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveStreamingMessagingMessageListenerAdapter.java
@@ -25,6 +25,7 @@ import org.springframework.pulsar.listener.adapter.HandlerAdapter;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarMessageHandler;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarStreamingHandler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import reactor.core.publisher.Flux;
 
 /**
@@ -39,8 +40,9 @@ import reactor.core.publisher.Flux;
 public class PulsarReactiveStreamingMessagingMessageListenerAdapter<V>
 		extends PulsarReactiveMessagingMessageListenerAdapter<V> implements ReactivePulsarStreamingHandler<V> {
 
-	public PulsarReactiveStreamingMessagingMessageListenerAdapter(Object bean, Method method) {
-		super(bean, method);
+	public PulsarReactiveStreamingMessagingMessageListenerAdapter(Object bean, Method method,
+			ObjectMapper objectMapper) {
+		super(bean, method, objectMapper);
 	}
 
 	@Override

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
@@ -57,6 +57,8 @@ import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * A {@link PulsarListenerEndpoint} providing the method to invoke to process an incoming
  * message for this endpoint.
@@ -73,6 +75,8 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 	private Object bean;
 
 	private Method method;
+
+	private ObjectMapper objectMapper;
 
 	private MessageHandlerMethodFactory messageHandlerMethodFactory;
 
@@ -109,6 +113,14 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 
 	public Method getMethod() {
 		return this.method;
+	}
+
+	public ObjectMapper getObjectMapper() {
+		return this.objectMapper;
+	}
+
+	public void setObjectMapper(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
 	}
 
 	public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory messageHandlerMethodFactory) {
@@ -239,12 +251,12 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 		AbstractPulsarMessageToSpringMessageAdapter<V> listener;
 		if (isBatchListener()) {
 			PulsarBatchMessagesToSpringMessageListenerAdapter<V> messageListener = new PulsarBatchMessagesToSpringMessageListenerAdapter<>(
-					this.bean, this.method);
+					this.bean, this.method, this.objectMapper);
 			listener = messageListener;
 		}
 		else {
 			PulsarRecordMessageToSpringMessageListenerAdapter<V> messageListener = new PulsarRecordMessageToSpringMessageListenerAdapter<>(
-					this.bean, this.method);
+					this.bean, this.method, this.objectMapper);
 			if (messageConverter instanceof PulsarMessageConverter) {
 				messageListener.setMessageConverter((PulsarMessageConverter) messageConverter);
 			}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarReaderEndpoint.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarReaderEndpoint.java
@@ -48,6 +48,8 @@ import org.springframework.pulsar.support.MessageConverter;
 import org.springframework.pulsar.support.converter.PulsarMessageConverter;
 import org.springframework.util.Assert;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * A {@link PulsarReaderEndpoint} providing the method to invoke to process an incoming
  * message for this endpoint.
@@ -62,6 +64,8 @@ public class MethodPulsarReaderEndpoint<V> extends AbstractPulsarReaderEndpoint<
 	private Object bean;
 
 	private Method method;
+
+	private ObjectMapper objectMapper;
 
 	private SmartMessageConverter messagingConverter;
 
@@ -87,6 +91,14 @@ public class MethodPulsarReaderEndpoint<V> extends AbstractPulsarReaderEndpoint<
 
 	public Method getMethod() {
 		return this.method;
+	}
+
+	public void setObjectMapper(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	public ObjectMapper getObjectMapper() {
+		return this.objectMapper;
 	}
 
 	@Override
@@ -175,7 +187,7 @@ public class MethodPulsarReaderEndpoint<V> extends AbstractPulsarReaderEndpoint<
 
 		AbstractPulsarMessageToSpringMessageAdapter<V> listener;
 		PulsarRecordMessageToSpringMessageReaderAdapter<V> messageListener = new PulsarRecordMessageToSpringMessageReaderAdapter<>(
-				this.bean, this.method);
+				this.bean, this.method, this.objectMapper);
 		if (messageConverter instanceof PulsarMessageConverter) {
 			messageListener.setMessageConverter((PulsarMessageConverter) messageConverter);
 		}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/AbstractPulsarMessageToSpringMessageAdapter.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/AbstractPulsarMessageToSpringMessageAdapter.java
@@ -43,6 +43,8 @@ import org.springframework.pulsar.support.converter.PulsarRecordMessageConverter
 import org.springframework.pulsar.support.header.JsonPulsarHeaderMapper;
 import org.springframework.util.Assert;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * An abstract {@link org.apache.pulsar.client.api.MessageListener} adapter providing the
  * necessary infrastructure to extract the payload from a Pulsar message.
@@ -81,13 +83,14 @@ public abstract class AbstractPulsarMessageToSpringMessageAdapter<V> {
 
 	private boolean converterSet;
 
-	private PulsarMessageConverter<V> messageConverter = new PulsarRecordMessageConverter<V>(
-			JsonPulsarHeaderMapper.builder().build());
+	private PulsarMessageConverter<V> messageConverter;
 
 	private Type fallbackType = Object.class;
 
-	public AbstractPulsarMessageToSpringMessageAdapter(Object bean, Method method) {
+	public AbstractPulsarMessageToSpringMessageAdapter(Object bean, Method method, ObjectMapper objectMapper) {
 		this.bean = bean;
+		this.messageConverter = new PulsarRecordMessageConverter<V>(
+				JsonPulsarHeaderMapper.builder().objectMapper(objectMapper).build());
 		this.inferredType = determineInferredType(method);
 	}
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarBatchMessagesToSpringMessageListenerAdapter.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarBatchMessagesToSpringMessageListenerAdapter.java
@@ -32,6 +32,8 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.pulsar.listener.Acknowledgement;
 import org.springframework.pulsar.listener.PulsarBatchAcknowledgingMessageListener;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * A {@link org.apache.pulsar.client.api.MessageListener MessageListener} adapter that
  * invokes a configurable {@link HandlerAdapter}; used when the factory is configured for
@@ -43,8 +45,8 @@ import org.springframework.pulsar.listener.PulsarBatchAcknowledgingMessageListen
 public class PulsarBatchMessagesToSpringMessageListenerAdapter<V> extends AbstractPulsarMessageToSpringMessageAdapter<V>
 		implements PulsarBatchAcknowledgingMessageListener<V> {
 
-	public PulsarBatchMessagesToSpringMessageListenerAdapter(Object bean, Method method) {
-		super(bean, method);
+	public PulsarBatchMessagesToSpringMessageListenerAdapter(Object bean, Method method, ObjectMapper objectMapper) {
+		super(bean, method, objectMapper);
 	}
 
 	@Override

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarRecordMessageToSpringMessageListenerAdapter.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarRecordMessageToSpringMessageListenerAdapter.java
@@ -26,6 +26,8 @@ import org.springframework.lang.Nullable;
 import org.springframework.pulsar.listener.Acknowledgement;
 import org.springframework.pulsar.listener.PulsarAcknowledgingMessageListener;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * A {@link MessageListener MessageListener} adapter that invokes a configurable
  * {@link HandlerAdapter}; used when the factory is configured for the listener to receive
@@ -37,8 +39,8 @@ import org.springframework.pulsar.listener.PulsarAcknowledgingMessageListener;
 public class PulsarRecordMessageToSpringMessageListenerAdapter<V> extends AbstractPulsarMessageToSpringMessageAdapter<V>
 		implements PulsarAcknowledgingMessageListener<V> {
 
-	public PulsarRecordMessageToSpringMessageListenerAdapter(Object bean, Method method) {
-		super(bean, method);
+	public PulsarRecordMessageToSpringMessageListenerAdapter(Object bean, Method method, ObjectMapper objectMapper) {
+		super(bean, method, objectMapper);
 	}
 
 	@Override

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarRecordMessageToSpringMessageReaderAdapter.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarRecordMessageToSpringMessageReaderAdapter.java
@@ -23,6 +23,8 @@ import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderListener;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 /**
  * A {@link MessageListener MessageListener} adapter that invokes a configurable
  * {@link HandlerAdapter}; used when the factory is configured for the listener to receive
@@ -34,8 +36,8 @@ import org.apache.pulsar.client.api.ReaderListener;
 public class PulsarRecordMessageToSpringMessageReaderAdapter<V> extends AbstractPulsarMessageToSpringMessageAdapter<V>
 		implements ReaderListener<V> {
 
-	public PulsarRecordMessageToSpringMessageReaderAdapter(Object bean, Method method) {
-		super(bean, method);
+	public PulsarRecordMessageToSpringMessageReaderAdapter(Object bean, Method method, ObjectMapper objectMapper) {
+		super(bean, method, objectMapper);
 	}
 
 	@Override


### PR DESCRIPTION
fix: https://github.com/spring-projects/spring-pulsar/issues/723 using builder of `JsonPulsarHeaderMapper`.

AS-IS
JacksonUtils.enhancedObjectMapper() was always used.
`JsonPulsarHeaderMapper.builder().build()`

TO-BE
Inject ObjectMapper to builder in the constructor of AbstractPulsarMessageToSpringMessageAdapter
`JsonPulsarHeaderMapper.builder().objectMapper(objectMapper).build()`

By adding ObjectMapper to the constructor of AbstractPulsarMessageToSpringMessageAdapter, we enable the use of a custom ObjectMapper.