### PR TITLE
Add support for custom object mapper

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -21,6 +21,7 @@
 *** xref:reference/reactive-pulsar/reactive-message-consumption.adoc[]
 *** xref:reference/tombstones-reactive.adoc[]
 ** xref:reference/topic-resolution.adoc[]
+** xref:reference/custom-object-mapper.adoc[]
 ** xref:reference/pulsar-admin.adoc[]
 ** xref:reference/pulsar-function.adoc[]
 ** xref:reference/observability.adoc[]

--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/custom-object-mapper.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/custom-object-mapper.adoc
@@ -1,0 +1,48 @@
+[[custom-object-mapper]]
+= Custom Object Mapper
+include::../attributes/attributes.adoc[]
+
+Pulsar uses an internal Jackson `ObjectMapper` when de/serializing JSON messages.
+If you instead want to provide your own object mapper instance, you can register a `SchemaResolverCustomizer` and set your mapper on the `DefaultSchemaResolver` as follows:
+
+[source,java,indent=0,subs="verbatim"]
+----
+@Bean
+SchemaResolverCustomizer<DefaultSchemaResolver> schemaResolverCustomizer() {
+    return (DefaultSchemaResolver schemaResolver) -> {
+        var myObjectMapper = obtainMyObjectMapper();
+        schemaResolver.setObjectMapper(myObjectMapper);
+    };
+}
+----
+
+This results in your object mapper being used to de/serialize all JSON messages that go through the schema resolution process (i.e. in cases where you do not pass a schema in directly when producing/consuming messages).
+
+Under the hood, the resolver creates a special JSON schema which leverages the custom mapper and is used as the schema for all resolved JSON messages.
+
+If you need to pass schema instances directly you can use the `JSONSchemaUtil` to create schemas that respect the custom mapper.
+The following example shows how to do this when sending a message with the `PulsarTemplate` variant that takes a schema parameter:
+
+[source,java,indent=0,subs="verbatim"]
+----
+void sendMessage(PulsarTemplate<MyPojo> template, MyPojo toSend) {
+    var myObjectMapper = obtainMyObjectMapper();
+    var schema = JSONSchemaUtil.schemaForTypeWithObjectMapper(MyPojo.class, myObjectMapper);
+    template.send(toSend, schema);
+}
+----
+
+
+[CAUTION]
+====
+Pulsar configures its default object mapper in a particular way.
+Unless you have a specific reason to not do so, it is highly recommended that you configure your mapper with these same options as follows:
+[source,java,indent=0,subs="verbatim"]
+----
+myObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+myObjectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, false);
+myObjectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+----
+
+====
+NOTE: A later version of the framework may instead provide a customizer that operates on the default mapper rather than requiring a separate instance.

--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -1,5 +1,15 @@
 = What's new?
 
+[[what-s-new-in-1-2-since-1-1]]
+== What's New in 1.2 Since 1.1
+:page-section-summary-toc: 1
+
+This section covers the changes made from version 1.1 to version 1.2.
+
+=== Custom Object Mapper
+You can provide your own Jackson `ObjectMapper` that Pulsar will use when producing and consuming JSON messages.
+See xref:./reference/custom-object-mapper.adoc[Custom Object Mapper] for more details.
+
 [[what-s-new-in-1-1-since-1-0]]
 == What's New in 1.1 Since 1.0
 :page-section-summary-toc: 1

--- a/spring-pulsar-reactive/spring-pulsar-reactive.gradle
+++ b/spring-pulsar-reactive/spring-pulsar-reactive.gradle
@@ -33,6 +33,7 @@ dependencies {
 	optional libs.json.path
 
 	testImplementation project(':spring-pulsar-test')
+	testImplementation(testFixtures(project(":spring-pulsar")))
 	testRuntimeOnly libs.logback.classic
 	testImplementation 'io.projectreactor:reactor-test'
 	testImplementation 'org.assertj:assertj-core'

--- a/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/ReactivePulsarListenerAutoConsumeSchemaTests.java
+++ b/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/ReactivePulsarListenerAutoConsumeSchemaTests.java
@@ -48,8 +48,8 @@ import org.springframework.pulsar.core.PulsarTemplate;
 import org.springframework.pulsar.reactive.config.annotation.ReactivePulsarListener;
 import org.springframework.pulsar.reactive.config.annotation.ReactivePulsarListenerMessageConsumerBuilderCustomizer;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarListenerAutoConsumeSchemaTests.ReactivePulsarListenerAutoConsumeSchemaTestsConfig;
-import org.springframework.pulsar.test.support.model.UserPojo;
-import org.springframework.pulsar.test.support.model.UserRecord;
+import org.springframework.pulsar.test.model.UserPojo;
+import org.springframework.pulsar.test.model.UserRecord;
 import org.springframework.test.context.ContextConfiguration;
 
 import reactor.core.publisher.Mono;

--- a/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/ReactivePulsarListenerTests.java
+++ b/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/ReactivePulsarListenerTests.java
@@ -74,8 +74,8 @@ import org.springframework.pulsar.reactive.listener.ReactivePulsarListenerTests.
 import org.springframework.pulsar.reactive.listener.ReactivePulsarListenerTests.SubscriptionTypeTests.WithSpecificTypes.WithSpecificTypesConfig;
 import org.springframework.pulsar.reactive.support.MessageUtils;
 import org.springframework.pulsar.support.PulsarHeaders;
-import org.springframework.pulsar.test.support.model.UserPojo;
-import org.springframework.pulsar.test.support.model.UserRecord;
+import org.springframework.pulsar.test.model.UserPojo;
+import org.springframework.pulsar.test.model.UserRecord;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.ObjectUtils;

--- a/spring-pulsar-sample-apps/sample-imperative-produce-consume/build.gradle
+++ b/spring-pulsar-sample-apps/sample-imperative-produce-consume/build.gradle
@@ -21,7 +21,10 @@ ext['pulsar.version'] = "${pulsarVersion}"
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-pulsar'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
-	testImplementation project(':spring-pulsar-test')
+	// temporary until JsonSchemaUtil published
+	implementation project(':spring-pulsar')
+	implementation(testFixtures(project(":spring-pulsar")))
+	implementation project(':spring-pulsar-test')
 	testRuntimeOnly 'ch.qos.logback:logback-classic'
 	testImplementation "org.springframework.boot:spring-boot-starter-test"
 	testImplementation "org.springframework.boot:spring-boot-testcontainers"

--- a/spring-pulsar-sample-apps/sample-reactive/build.gradle
+++ b/spring-pulsar-sample-apps/sample-reactive/build.gradle
@@ -23,7 +23,10 @@ ext['pulsar-reactive.version'] = "${pulsarReactiveVersion}"
 dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-pulsar-reactive"
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
-	testImplementation project(':spring-pulsar-test')
+	// temporary until JsonSchemaUtil published
+	implementation project(':spring-pulsar')
+	implementation(testFixtures(project(":spring-pulsar")))
+	implementation project(':spring-pulsar-test')
 	testRuntimeOnly 'ch.qos.logback:logback-classic'
 	testImplementation "org.springframework.boot:spring-boot-starter-test"
 	testImplementation "org.springframework.boot:spring-boot-testcontainers"

--- a/spring-pulsar-sample-apps/sample-reactive/src/test/java/com/example/ReactiveSpringPulsarBootAppTests.java
+++ b/spring-pulsar-sample-apps/sample-reactive/src/test/java/com/example/ReactiveSpringPulsarBootAppTests.java
@@ -16,13 +16,14 @@
 
 package com.example;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
-import com.example.ReactiveSpringPulsarBootApp.Foo;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,11 +31,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.pulsar.test.model.UserRecord;
 import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.example.ReactiveSpringPulsarBootApp.Foo;
 
 @SpringBootTest
 @ExtendWith(OutputCaptureExtension.class)
@@ -61,13 +63,30 @@ class ReactiveSpringPulsarBootAppTests implements PulsarTestContainerSupport {
 		verifyProduceConsume(output,10, (i) -> "ReactiveTemplateWithImperativeListener:" + i);
 	}
 
+	@Test
+	void produceConsumeCustomObjectMapper(CapturedOutput output) {
+		// base age is 30 then ser adds 10 then deser adds 5
+		var expectedAge = 30 + 10 + 5;
+		verifyProduceConsume(output, 10,
+				(i) -> new UserRecord("user-%d".formatted(i), 30),
+				(i) -> new UserRecord("user-%d-ser-deser".formatted(i), expectedAge));
+
+	}
+
 	private void verifyProduceConsume(CapturedOutput output, int numExpectedMessages,
 			Function<Integer, Object> expectedMessageFactory) {
-		List < String > expectedOutput = new ArrayList<>();
+		this.verifyProduceConsume(output, numExpectedMessages, expectedMessageFactory, expectedMessageFactory);
+	}
+
+	private void verifyProduceConsume(CapturedOutput output, int numExpectedMessages,
+			Function<Integer, Object> expectedProducedMessageFactory,
+			Function<Integer, Object> expectedConsumedMessageFactory) {
+		List<String> expectedOutput = new ArrayList<>();
 		IntStream.range(0, numExpectedMessages).forEachOrdered((i) -> {
-			var msg = expectedMessageFactory.apply(i);
-			expectedOutput.add("++++++PRODUCE %s------".formatted(msg));
-			expectedOutput.add("++++++CONSUME %s------".formatted(msg));
+			var expectedProducedMsg = expectedProducedMessageFactory.apply(i);
+			var expectedConsumedMsg = expectedConsumedMessageFactory.apply(i);
+			expectedOutput.add("++++++PRODUCE %s------".formatted(expectedProducedMsg));
+			expectedOutput.add("++++++CONSUME %s------".formatted(expectedConsumedMsg));
 		});
 		Awaitility.waitAtMost(Duration.ofSeconds(15))
 				.untilAsserted(() -> assertThat(output).contains(expectedOutput));

--- a/spring-pulsar/spring-pulsar.gradle
+++ b/spring-pulsar/spring-pulsar.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'org.springframework.pulsar.spring-module'
+	id 'java-test-fixtures'
 }
 
 description = 'Spring Pulsar Core'
@@ -51,4 +52,6 @@ dependencies {
 	testImplementation "org.testcontainers:mysql"
 	testImplementation 'mysql:mysql-connector-java:8.0.33'
 
+	// Used by UserRecordDe/serializer in test fixtures
+	testFixturesApi 'com.fasterxml.jackson.core:jackson-databind'
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/JSONSchemaUtil.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/JSONSchemaUtil.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.core;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Consumer;
+
+import org.apache.pulsar.client.api.SchemaSerializationException;
+import org.apache.pulsar.client.api.schema.SchemaDefinitionBuilder;
+import org.apache.pulsar.client.api.schema.SchemaReader;
+import org.apache.pulsar.client.api.schema.SchemaWriter;
+import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.client.impl.schema.SchemaDefinitionBuilderImpl;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+/**
+ * Factory to create schema definition {@link SchemaDefinitionBuilder builders} that
+ * provide schema definitions that use custom object mappers when de/serializing objects.
+ *
+ * @author Chris Bono
+ * @since 1.2.0
+ */
+public interface JSONSchemaUtil {
+
+	/**
+	 * Create a new JSON schema that uses the provided object mapper to de/serialize
+	 * objects of the specified type.
+	 * @param objectType the type of objects the resulting schema represents
+	 * @param objectMapper the mapper used to read and write objects from JSON
+	 * @param <T> the type of objects the resulting schema represents
+	 * @return the schema instance
+	 */
+	static <T> JSONSchema<T> schemaForTypeWithObjectMapper(Class<T> objectType, ObjectMapper objectMapper) {
+		return JSONSchemaUtil.schemaForTypeWithObjectMapper(objectType, objectMapper, (b) -> {
+		});
+	}
+
+	/**
+	 * Create a new JSON schema that uses the provided object mapper to de/serialize
+	 * objects of the specified type.
+	 * @param objectType the type of objects the resulting schema represents
+	 * @param objectMapper the mapper used to read and write objects from JSON
+	 * @param schemaDefinitionBuilderCustomizer the schema definition builder customizer
+	 * @param <T> the type of objects the resulting schema represents
+	 * @return the schema instance
+	 */
+	static <T> JSONSchema<T> schemaForTypeWithObjectMapper(Class<T> objectType, ObjectMapper objectMapper,
+			Consumer<SchemaDefinitionBuilder<T>> schemaDefinitionBuilderCustomizer) {
+		var reader = new CustomJacksonJsonReader<>(objectMapper, objectType);
+		var writer = new CustomJacksonJsonWriter<T>(objectMapper);
+		var schemaDefinitionBuilder = new SchemaDefinitionBuilderImpl<T>().withPojo(objectType)
+			.withSchemaReader(reader)
+			.withSchemaWriter(writer);
+		schemaDefinitionBuilderCustomizer.accept(schemaDefinitionBuilder);
+		return JSONSchema.of(schemaDefinitionBuilder.build());
+	}
+
+	/**
+	 * Reader implementation for reading objects from JSON using a custom
+	 * {@code ObjectMapper}.
+	 *
+	 * @param <T> object type to read
+	 */
+	class CustomJacksonJsonReader<T> implements SchemaReader<T> {
+
+		private static final LogAccessor LOG = new LogAccessor(CustomJacksonJsonReader.class);
+
+		private final ObjectReader objectReader;
+
+		private final Class<T> objectType;
+
+		CustomJacksonJsonReader(ObjectMapper objectMapper, Class<T> objectType) {
+			Assert.notNull(objectMapper, "objectMapper must not be null");
+			Assert.notNull(objectType, "objectType must not be null");
+			this.objectReader = objectMapper.readerFor(objectType);
+			this.objectType = objectType;
+		}
+
+		@Override
+		public T read(byte[] bytes, int offset, int length) {
+			try {
+				return this.objectReader.readValue(bytes, offset, length);
+			}
+			catch (IOException e) {
+				throw new SchemaSerializationException(e);
+			}
+		}
+
+		@Override
+		public T read(InputStream inputStream) {
+			try {
+				return this.objectReader.readValue(inputStream, this.objectType);
+			}
+			catch (IOException e) {
+				throw new SchemaSerializationException(e);
+			}
+			finally {
+				try {
+					inputStream.close();
+				}
+				catch (IOException e) {
+					LOG.error(e, () -> "Failed to close input stream on read");
+				}
+			}
+		}
+
+	}
+
+	/**
+	 * Writer implementation for writing objects as JSON using a custom
+	 * {@code ObjectMapper}.
+	 *
+	 * @param <T> object type to write
+	 */
+	class CustomJacksonJsonWriter<T> implements SchemaWriter<T> {
+
+		private final ObjectMapper objectMapper;
+
+		CustomJacksonJsonWriter(ObjectMapper objectMapper) {
+			Assert.notNull(objectMapper, "objectMapper must not be null");
+			this.objectMapper = objectMapper;
+		}
+
+		@Override
+		public byte[] write(T message) {
+			try {
+				return this.objectMapper.writeValueAsBytes(message);
+			}
+			catch (JsonProcessingException e) {
+				throw new SchemaSerializationException(e);
+			}
+		}
+
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
@@ -49,7 +49,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.pulsar.cache.provider.CacheProvider;
 import org.springframework.pulsar.core.CachingPulsarProducerFactory.ProducerCacheKey;
 import org.springframework.pulsar.core.CachingPulsarProducerFactory.ProducerWithCloseCallback;
-import org.springframework.pulsar.test.support.model.UserPojo;
+import org.springframework.pulsar.test.model.UserPojo;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.ObjectUtils;
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/JsonSchemaUtilTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/JsonSchemaUtilTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-package org.springframework.pulsar.test.support.model;
+package org.springframework.pulsar.core;
+
+import org.junit.jupiter.api.Test;
 
 /**
- * Test object (user) defined via a Java record.
- *
- * @param name the user's name
- * @param age the user's age
- * @deprecated this class is replaced with Gradle test fixtures and is only meant to be
- * used internally.
+ * Tests for {@link JSONSchemaUtil}.
  */
-@Deprecated(since = "1.2.0", forRemoval = true)
-public record UserRecord(String name, int age) {
+class JsonSchemaUtilTests {
+
+	@Test
+	void foo() {
+	}
+
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
@@ -59,8 +59,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.pulsar.annotation.EnablePulsar;
+import org.springframework.pulsar.test.model.UserRecord;
+import org.springframework.pulsar.test.model.json.UserRecordObjectMapper;
 import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
-import org.springframework.pulsar.test.support.model.UserRecord;
 import org.springframework.util.function.ThrowingConsumer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -444,6 +445,24 @@ class PulsarTemplateTests implements PulsarTestContainerSupport {
 		@EnablePulsar
 		static class PulsarTemplateCustomizerTestsConfig {
 
+		}
+
+	}
+
+	@Nested
+	class CustomObjectMapperTests {
+
+		@Test
+		void sendWithCustomJsonSchema() throws Exception {
+			// Prepare the schema with custom object mapper
+			var objectMapper = UserRecordObjectMapper.withSer();
+			var schema = JSONSchemaUtil.schemaForTypeWithObjectMapper(UserRecord.class, objectMapper);
+			var topic = "ptt-custom-object-mapper-topic";
+			var user = new UserRecord("elFoo", 21);
+			// serializer adds '-ser' to name and 10 to age
+			var expectedUser = new UserRecord("elFoo-ser", 31);
+			ThrowingConsumer<PulsarTemplate<UserRecord>> sendFunction = (template) -> template.send(user, schema);
+			sendAndConsume(sendFunction, topic, schema, expectedUser, true);
 		}
 
 	}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerAutoConsumeSchemaTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerAutoConsumeSchemaTests.java
@@ -45,8 +45,8 @@ import org.springframework.pulsar.annotation.PulsarListener;
 import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
 import org.springframework.pulsar.listener.PulsarListenerAutoConsumeSchemaTests.PulsarListenerAutoConsumeSchemaTestsConfig;
-import org.springframework.pulsar.test.support.model.UserPojo;
-import org.springframework.pulsar.test.support.model.UserRecord;
+import org.springframework.pulsar.test.model.UserPojo;
+import org.springframework.pulsar.test.model.UserRecord;
 import org.springframework.test.context.ContextConfiguration;
 
 /**

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -72,8 +72,8 @@ import org.springframework.pulsar.core.TopicResolver;
 import org.springframework.pulsar.listener.PulsarListenerTests.SubscriptionTypeTests.WithDefaultType.WithDefaultTypeConfig;
 import org.springframework.pulsar.listener.PulsarListenerTests.SubscriptionTypeTests.WithSpecificTypes.WithSpecificTypesConfig;
 import org.springframework.pulsar.support.PulsarHeaders;
-import org.springframework.pulsar.test.support.model.UserPojo;
-import org.springframework.pulsar.test.support.model.UserRecord;
+import org.springframework.pulsar.test.model.UserPojo;
+import org.springframework.pulsar.test.model.UserRecord;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.util.backoff.FixedBackOff;
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/reader/PulsarReaderAutoConsumeSchemaTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/reader/PulsarReaderAutoConsumeSchemaTests.java
@@ -45,8 +45,8 @@ import org.springframework.pulsar.annotation.PulsarReader;
 import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
 import org.springframework.pulsar.reader.PulsarReaderAutoConsumeSchemaTests.PulsarReaderAutoConsumeSchemaTestsConfig;
-import org.springframework.pulsar.test.support.model.UserPojo;
-import org.springframework.pulsar.test.support.model.UserRecord;
+import org.springframework.pulsar.test.model.UserPojo;
+import org.springframework.pulsar.test.model.UserRecord;
 import org.springframework.test.context.ContextConfiguration;
 
 /**

--- a/spring-pulsar/src/testFixtures/java/org/springframework/pulsar/test/model/UserPojo.java
+++ b/spring-pulsar/src/testFixtures/java/org/springframework/pulsar/test/model/UserPojo.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.pulsar.test.support.model;
+package org.springframework.pulsar.test.model;
 
 import java.util.Objects;
 
@@ -23,11 +23,7 @@ import java.util.Objects;
  * <p>
  * <b>WARN</b> Do not convert this to a Record as this is used for Avro tests and Avro
  * does not work well w/ records yet.
- *
- * @deprecated this class is replaced with Gradle test fixtures and is only meant to be
- * used internally.
  */
-@Deprecated(since = "1.2.0", forRemoval = true)
 public class UserPojo {
 
 	private String name;

--- a/spring-pulsar/src/testFixtures/java/org/springframework/pulsar/test/model/UserRecord.java
+++ b/spring-pulsar/src/testFixtures/java/org/springframework/pulsar/test/model/UserRecord.java
@@ -14,16 +14,13 @@
  * limitations under the License.
  */
 
-package org.springframework.pulsar.test.support.model;
+package org.springframework.pulsar.test.model;
 
 /**
  * Test object (user) defined via a Java record.
  *
  * @param name the user's name
  * @param age the user's age
- * @deprecated this class is replaced with Gradle test fixtures and is only meant to be
- * used internally.
  */
-@Deprecated(since = "1.2.0", forRemoval = true)
 public record UserRecord(String name, int age) {
 }

--- a/spring-pulsar/src/testFixtures/java/org/springframework/pulsar/test/model/json/UserRecordDeserializer.java
+++ b/spring-pulsar/src/testFixtures/java/org/springframework/pulsar/test/model/json/UserRecordDeserializer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.test.model.json;
+
+import java.io.IOException;
+
+import org.springframework.pulsar.test.model.UserRecord;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * Custom Jackson deserializer for {@link UserRecord}.
+ *
+ * @author Chris Bono
+ * @since 1.2.0
+ */
+public class UserRecordDeserializer extends StdDeserializer<UserRecord> {
+
+	public UserRecordDeserializer() {
+		this(null);
+	}
+
+	public UserRecordDeserializer(Class<UserRecord> t) {
+		super(t);
+	}
+
+	@Override
+	public UserRecord deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+		JsonNode rootNode = jp.getCodec().readTree(jp);
+		var name = rootNode.get("name").asText();
+		var age = rootNode.get("age").asInt();
+		return new UserRecord(name + "-deser", age + 5);
+	}
+
+}

--- a/spring-pulsar/src/testFixtures/java/org/springframework/pulsar/test/model/json/UserRecordObjectMapper.java
+++ b/spring-pulsar/src/testFixtures/java/org/springframework/pulsar/test/model/json/UserRecordObjectMapper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.test.model.json;
+
+import org.springframework.pulsar.test.model.UserRecord;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * Constructs custom {@link ObjectMapper} instances that leverage the
+ * {@link UserRecordSerializer} and {@link UserRecordDeserializer}.
+ */
+public final class UserRecordObjectMapper {
+
+	private UserRecordObjectMapper() {
+	}
+
+	public static ObjectMapper withSer() {
+		var objectMapper = new ObjectMapper();
+		var module = new SimpleModule();
+		module.addSerializer(UserRecord.class, new UserRecordSerializer());
+		objectMapper.registerModule(module);
+		return objectMapper;
+	}
+
+	public static ObjectMapper withDeser() {
+		var objectMapper = new ObjectMapper();
+		var module = new SimpleModule();
+		module.addDeserializer(UserRecord.class, new UserRecordDeserializer());
+		objectMapper.registerModule(module);
+		return objectMapper;
+	}
+
+	public static ObjectMapper withSerAndDeser() {
+		var objectMapper = new ObjectMapper();
+		var module = new SimpleModule();
+		module.addSerializer(UserRecord.class, new UserRecordSerializer());
+		module.addDeserializer(UserRecord.class, new UserRecordDeserializer());
+		objectMapper.registerModule(module);
+		return objectMapper;
+	}
+
+}

--- a/spring-pulsar/src/testFixtures/java/org/springframework/pulsar/test/model/json/UserRecordSerializer.java
+++ b/spring-pulsar/src/testFixtures/java/org/springframework/pulsar/test/model/json/UserRecordSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.test.model.json;
+
+import java.io.IOException;
+
+import org.springframework.pulsar.test.model.UserRecord;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Custom Jackson serializer for {@link UserRecord}.
+ *
+ * @author Chris Bono
+ * @since 1.2.0
+ */
+public class UserRecordSerializer extends StdSerializer<UserRecord> {
+
+	public UserRecordSerializer() {
+		this(null);
+	}
+
+	public UserRecordSerializer(Class<UserRecord> t) {
+		super(t);
+	}
+
+	@Override
+	public void serialize(UserRecord value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+		jgen.writeStartObject();
+		jgen.writeStringField("name", value.name() + "-ser");
+		jgen.writeNumberField("age", value.age() + 10);
+		jgen.writeEndObject();
+	}
+
+}


### PR DESCRIPTION
This commit adds support for a user-provided Jackson ObjectMapper to be used when de/serializing JSON messages.

Additionally, adds Gradle test fixtures to the spring-pulsar module and deprecates the UserRecord and UserPojo in spring-pulsar-test in favor of their equivalent in the test fixture.

See https://github.com/spring-projects/spring-pulsar/issues/723