### PR TITLE
Allow custom object mapper for headers

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar-header.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar-header.adoc
@@ -43,6 +43,24 @@ The `JsonPulsarHeaderMapper` has a property called `addToStringClasses()` that l
 During inbound mapping, they are mapped as `String`.
 By default, only `org.springframework.util.MimeType` and `org.springframework.http.MediaType` are mapped this way.
 
+===== Custom ObjectMapper
+The JSON mapper uses a reasonable configured Jasckson `ObjectMapper` to handle serialization of header values.
+However, to provide a custom object mapper one must simply provide an `ObjectMapper` bean with the name `pulsarHeaderObjectMapper`.
+For example:
+[source, java]
+----
+@Configuration(proxyBeanMethods = false)
+static class PulsarHeadersCustomObjectMapperTestConfig {
+
+    @Bean(name = "pulsarHeaderObjectMapper")
+    ObjectMapper customObjectMapper() {
+        var objectMapper = new ObjectMapper();
+		// do things with your special header object mapper here
+        return objectMapper;
+    }
+}
+----
+
 === Inbound/Outbound Patterns
 On the inbound side, by default, all Pulsar headers (message metadata plus user properties) are mapped to `MessageHeaders`.
 On the outbound side, by default, all `MessageHeaders` are mapped, except `id`, `timestamp`, and the headers that represent the Pulsar message metadata.

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
@@ -46,6 +46,7 @@ import org.springframework.format.Formatter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.lang.Nullable;
 import org.springframework.pulsar.annotation.AbstractPulsarAnnotationsBeanPostProcessor;
+import org.springframework.pulsar.annotation.PulsarHeaderObjectMapperUtils;
 import org.springframework.pulsar.annotation.PulsarListenerConfigurer;
 import org.springframework.pulsar.config.PulsarAnnotationSupportBeanNames;
 import org.springframework.pulsar.config.PulsarListenerEndpointRegistrar;
@@ -79,6 +80,7 @@ import org.springframework.util.StringUtils;
  * @param <V> the payload type.
  * @author Christophe Bornet
  * @author Soby Chacko
+ * @author Jihoon Kim
  * @see ReactivePulsarListener
  * @see EnableReactivePulsar
  * @see PulsarListenerConfigurer
@@ -281,6 +283,9 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V> extends Abstra
 
 	@SuppressWarnings("unchecked")
 	protected void postProcessEndpointsBeforeRegistration() {
+		PulsarHeaderObjectMapperUtils.customMapper(this.beanFactory)
+			.ifPresent((objectMapper) -> this.processedEndpoints
+				.forEach((endpoint) -> endpoint.setObjectMapper(objectMapper)));
 		if (this.processedEndpoints.size() == 1) {
 			MethodReactivePulsarListenerEndpoint<?> endpoint = this.processedEndpoints.get(0);
 			if (endpoint.getConsumerCustomizer() != null) {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarHeaderObjectMapperUtils.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarHeaderObjectMapperUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.annotation;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Resolves the {@link ObjectMapper} to use when serializing JSON header values.
+ *
+ * @author Chris Bono
+ * @since 1.2.0
+ */
+public final class PulsarHeaderObjectMapperUtils {
+
+	private static final String PULSAR_HEADER_OBJECT_MAPPER_BEAN_NAME = "pulsarHeaderObjectMapper";
+
+	private static final LogAccessor LOG = new LogAccessor(PulsarHeaderObjectMapperUtils.class);
+
+	private PulsarHeaderObjectMapperUtils() {
+	}
+
+	/**
+	 * Gets the optional {@link ObjectMapper} to use when deserializing JSON header
+	 * values. The mapper bean is expected to be registered with the name
+	 * 'pulsarHeaderObjectMapper'.
+	 * @param beanFactory the bean factory that may contain the mapper bean
+	 * @return optional mapper or empty if bean not registered under the expected name
+	 */
+	public static Optional<ObjectMapper> customMapper(BeanFactory beanFactory) {
+		Assert.notNull(beanFactory, "beanFactory must not be null");
+		try {
+			return Optional.of(beanFactory.getBean(PULSAR_HEADER_OBJECT_MAPPER_BEAN_NAME, ObjectMapper.class));
+		}
+		catch (NoSuchBeanDefinitionException ex) {
+			LOG.debug(() -> "No '%s' bean defined - will use standard object mapper for header values"
+				.formatted(PULSAR_HEADER_OBJECT_MAPPER_BEAN_NAME));
+		}
+		return Optional.empty();
+	}
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
@@ -76,6 +76,7 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author Chris Bono
  * @author Alexander Preuß
+ * @author Jihoon Kim
  * @see PulsarListener
  * @see EnablePulsar
  * @see PulsarListenerConfigurer
@@ -270,6 +271,9 @@ public class PulsarListenerAnnotationBeanPostProcessor<V> extends AbstractPulsar
 
 	@SuppressWarnings("unchecked")
 	protected void postProcessEndpointsBeforeRegistration() {
+		PulsarHeaderObjectMapperUtils.customMapper(this.beanFactory)
+			.ifPresent((objectMapper) -> this.processedEndpoints
+				.forEach((endpoint) -> endpoint.setObjectMapper(objectMapper)));
 		if (this.processedEndpoints.size() == 1) {
 			MethodPulsarListenerEndpoint<?> endpoint = this.processedEndpoints.get(0);
 			if (endpoint.getConsumerBuilderCustomizer() != null) {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarReaderAnnotationBeanPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarReaderAnnotationBeanPostProcessor.java
@@ -70,6 +70,7 @@ import org.springframework.util.StringUtils;
  *
  * @param <V> the payload type.
  * @author Soby Chacko
+ * @author Jihoon Kim
  * @see PulsarReader
  * @see EnablePulsar
  * @see PulsarReaderConfigurer
@@ -237,6 +238,9 @@ public class PulsarReaderAnnotationBeanPostProcessor<V> extends AbstractPulsarAn
 
 	@SuppressWarnings("unchecked")
 	protected void postProcessEndpointsBeforeRegistration() {
+		PulsarHeaderObjectMapperUtils.customMapper(this.beanFactory)
+			.ifPresent((objectMapper) -> this.processedEndpoints
+				.forEach((endpoint) -> endpoint.setObjectMapper(objectMapper)));
 		if (this.processedEndpoints.size() == 1) {
 			MethodPulsarReaderEndpoint<?> endpoint = this.processedEndpoints.get(0);
 			if (endpoint.getReaderBuilderCustomizer() != null) {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/annotation/PulsarHeaderObjectMapperUtilsTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/annotation/PulsarHeaderObjectMapperUtilsTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Tests for {@link PulsarHeaderObjectMapperUtils}.
+ */
+class PulsarHeaderObjectMapperUtilsTests {
+
+	@Test
+	void whenCustomMapperDefinedItIsReturned() {
+		var mapper = new ObjectMapper();
+		var beanFactory = mock(BeanFactory.class);
+		when(beanFactory.getBean("pulsarHeaderObjectMapper", ObjectMapper.class)).thenReturn(mapper);
+		assertThat(PulsarHeaderObjectMapperUtils.customMapper(beanFactory)).hasValue(mapper);
+	}
+
+	@Test
+	void whenCustomMapperIsNotDefinedEmptyIsReturned() {
+		var beanFactory = mock(BeanFactory.class);
+		when(beanFactory.getBean("pulsarHeaderObjectMapper", ObjectMapper.class))
+			.thenThrow(new NoSuchBeanDefinitionException("pulsarHeaderObjectMapper"));
+		assertThat(PulsarHeaderObjectMapperUtils.customMapper(beanFactory)).isEmpty();
+	}
+
+	@Test
+	void whenBeanFactoryNullExceptionIsThrown() {
+		assertThatIllegalArgumentException().isThrownBy(() -> PulsarHeaderObjectMapperUtils.customMapper(null))
+			.withMessage("beanFactory must not be null");
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/reader/PulsarReaderHeaderTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/reader/PulsarReaderHeaderTests.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.pulsar.client.api.MessageId;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.pulsar.annotation.PulsarReader;
+import org.springframework.pulsar.reader.PulsarReaderHeaderTests.WithCustomObjectMapperTest.WithCustomObjectMapperTestConfig;
+import org.springframework.pulsar.reader.PulsarReaderHeaderTests.WithStandardObjectMapperTest.WithStandardObjectMapperTestConfig;
+import org.springframework.pulsar.support.header.JsonPulsarHeaderMapper;
+import org.springframework.pulsar.test.model.UserRecord;
+import org.springframework.pulsar.test.model.json.UserRecordDeserializer;
+import org.springframework.test.context.ContextConfiguration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * Tests consuming records with header in {@link PulsarReader @PulsarReader}.
+ *
+ * @author Chris Bono
+ */
+class PulsarReaderHeaderTests extends PulsarReaderTestsBase {
+
+	@Nested
+	@ContextConfiguration(classes = WithStandardObjectMapperTestConfig.class)
+	class WithStandardObjectMapperTest {
+
+		private static final String TOPIC = "prht-with-standard-mapper-topic";
+
+		private static CountDownLatch listenerLatch = new CountDownLatch(1);
+
+		private static UserRecord userPassedIntoListener;
+
+		@Test
+		void whenObjectMapperIsNotDefinedThenStandardMapperUsedToDeserHeaders() throws Exception {
+			var msg = "hello-%s".formatted(TOPIC);
+			// In order to send complex headers (pojo) must manually map and set each
+			// header as follows
+			var user = new UserRecord("that", 100);
+			var headers = new HashMap<String, Object>();
+			headers.put("user", user);
+			var headerMapper = JsonPulsarHeaderMapper.builder().build();
+			var mappedHeaders = headerMapper.toPulsarHeaders(new MessageHeaders(headers));
+			pulsarTemplate.newMessage(msg)
+				.withMessageCustomizer(messageBuilder -> mappedHeaders.forEach(messageBuilder::property))
+				.withTopic(TOPIC)
+				.send();
+			assertThat(listenerLatch.await(5, TimeUnit.SECONDS)).isTrue();
+			assertThat(userPassedIntoListener).isEqualTo(user);
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		static class WithStandardObjectMapperTestConfig {
+
+			@PulsarReader(topics = TOPIC, startMessageId = "earliest")
+			public void listenWithHeaders(org.apache.pulsar.client.api.Message<String> msg,
+					@Header("user") UserRecord user) {
+				userPassedIntoListener = user;
+				listenerLatch.countDown();
+			}
+
+		}
+
+	}
+
+	@Nested
+	@ContextConfiguration(classes = WithCustomObjectMapperTestConfig.class)
+	class WithCustomObjectMapperTest {
+
+		private static final String TOPIC = "prht-with-custom-mapper-topic";
+
+		private static CountDownLatch listenerLatch = new CountDownLatch(1);
+
+		private static UserRecord userPassedIntoListener;
+
+		@Test
+		void whenObjectMapperIsDefinedThenItIsUsedToDeserHeaders() throws Exception {
+			var msg = "hello-%s".formatted(TOPIC);
+			// In order to send complex headers (pojo) must manually map and set each
+			// header as follows
+			var user = new UserRecord("that", 100);
+			var headers = new HashMap<String, Object>();
+			headers.put("user", user);
+			var headerMapper = JsonPulsarHeaderMapper.builder().build();
+			var mappedHeaders = headerMapper.toPulsarHeaders(new MessageHeaders(headers));
+			MessageId messageId = pulsarTemplate.newMessage(msg)
+				.withMessageCustomizer(messageBuilder -> mappedHeaders.forEach(messageBuilder::property))
+				.withTopic(TOPIC)
+				.send();
+			// Custom deser adds suffix to name and bumps age + 5
+			var expectedUser = new UserRecord(user.name() + "-deser", user.age() + 5);
+			assertThat(listenerLatch.await(5, TimeUnit.SECONDS)).isTrue();
+			assertThat(userPassedIntoListener).isEqualTo(expectedUser);
+		}
+
+		@Configuration(proxyBeanMethods = false)
+		static class WithCustomObjectMapperTestConfig {
+
+			@Bean(name = "pulsarHeaderObjectMapper")
+			ObjectMapper customObjectMapper() {
+				var objectMapper = new ObjectMapper();
+				var module = new SimpleModule();
+				module.addDeserializer(UserRecord.class, new UserRecordDeserializer());
+				objectMapper.registerModule(module);
+				return objectMapper;
+			}
+
+			@PulsarReader(topics = TOPIC, startMessageId = "earliest")
+			public void listenWithHeaders(org.apache.pulsar.client.api.Message<String> msg,
+					@Header("user") UserRecord user) {
+				userPassedIntoListener = user;
+				listenerLatch.countDown();
+			}
+
+		}
+
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/support/header/JsonPulsarHeaderMapperTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/support/header/JsonPulsarHeaderMapperTests.java
@@ -118,6 +118,7 @@ class JsonPulsarHeaderMapperTests extends AbstractPulsarHeaderMapperTests {
 			var headers = new HashMap<String, Object>();
 			headers.put("foo", "bar");
 			headers.put("uuid", uuid);
+			var mapped = mapper().toPulsarHeaders(new MessageHeaders(headers));
 			assertThat(mapper().toPulsarHeaders(new MessageHeaders(headers))).containsEntry("foo", "bar")
 				.containsEntry("uuid", "\"%s\"".formatted(uuid.toString()))
 				.extractingByKey(JSON_TYPES, InstanceOfAssertFactories.STRING)


### PR DESCRIPTION
This commit adds support for a user-provided Jackson ObjectMapper to be used when deserializing JSON header values.

See #723

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
