### PR TITLE
Use auto-configured PulsarTopicBuilder

### DIFF
--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/app/ImperativeAppConfig.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/app/ImperativeAppConfig.java
@@ -39,8 +39,8 @@ class ImperativeAppConfig {
 	private static final String TOPIC = "pulsar-inttest-topic";
 
 	@Bean
-	PulsarTopic pulsarTestTopic() {
-		return new PulsarTopicBuilder().name(TOPIC).numberOfPartitions(1).build();
+	PulsarTopic pulsarTestTopic(PulsarTopicBuilder topicBuilder) {
+		return topicBuilder.name(TOPIC).numberOfPartitions(1).build();
 	}
 
 	@Bean

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/app/ReactiveAppConfig.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/app/ReactiveAppConfig.java
@@ -43,8 +43,8 @@ class ReactiveAppConfig {
 	private static final String TOPIC = "pulsar-reactive-inttest-topic";
 
 	@Bean
-	PulsarTopic pulsarTestTopic() {
-		return new PulsarTopicBuilder().name(TOPIC).numberOfPartitions(1).build();
+	PulsarTopic pulsarTestTopic(PulsarTopicBuilder topicBuilder) {
+		return topicBuilder.name(TOPIC).numberOfPartitions(1).build();
 	}
 
 	@Bean

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/DefaultTenantAndNamespaceTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/DefaultTenantAndNamespaceTests.java
@@ -50,7 +50,10 @@ class DefaultTenantAndNamespaceTests {
 	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage());
 
 	@Nested
-	@SpringBootTest(classes = ImperativeAppConfig.class)
+	@SpringBootTest(classes = ImperativeAppConfig.class, properties = {
+			"spring.pulsar.defaults.topic.tenant=my-tenant-i",
+			"spring.pulsar.defaults.topic.namespace=my-namespace-i"
+	})
 	@ExtendWith(OutputCaptureExtension.class)
 	@ActiveProfiles("inttest.pulsar.imperative")
 	class WithImperativeApp {
@@ -66,7 +69,10 @@ class DefaultTenantAndNamespaceTests {
 	}
 
 	@Nested
-	@SpringBootTest(classes = ReactiveAppConfig.class)
+	@SpringBootTest(classes = ReactiveAppConfig.class, properties = {
+			"spring.pulsar.defaults.topic.tenant=my-tenant-r",
+			"spring.pulsar.defaults.topic.namespace=my-namespace-r"
+	})
 	@ExtendWith(OutputCaptureExtension.class)
 	@ActiveProfiles("inttest.pulsar.reactive")
 	class WithReactiveApp {

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/DefaultTenantAndNamespaceTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/DefaultTenantAndNamespaceTests.java
@@ -50,10 +50,9 @@ class DefaultTenantAndNamespaceTests {
 	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage());
 
 	@Nested
-	@SpringBootTest(classes = ImperativeAppConfig.class, properties = {
-			"spring.pulsar.defaults.topic.tenant=my-tenant-i",
-			"spring.pulsar.defaults.topic.namespace=my-namespace-i"
-	})
+	@SpringBootTest(classes = ImperativeAppConfig.class,
+			properties = { "spring.pulsar.defaults.topic.tenant=my-tenant-i",
+					"spring.pulsar.defaults.topic.namespace=my-namespace-i" })
 	@ExtendWith(OutputCaptureExtension.class)
 	@ActiveProfiles("inttest.pulsar.imperative")
 	class WithImperativeApp {
@@ -69,10 +68,9 @@ class DefaultTenantAndNamespaceTests {
 	}
 
 	@Nested
-	@SpringBootTest(classes = ReactiveAppConfig.class, properties = {
-			"spring.pulsar.defaults.topic.tenant=my-tenant-r",
-			"spring.pulsar.defaults.topic.namespace=my-namespace-r"
-	})
+	@SpringBootTest(classes = ReactiveAppConfig.class,
+			properties = { "spring.pulsar.defaults.topic.tenant=my-tenant-r",
+					"spring.pulsar.defaults.topic.namespace=my-namespace-r" })
 	@ExtendWith(OutputCaptureExtension.class)
 	@ActiveProfiles("inttest.pulsar.reactive")
 	class WithReactiveApp {

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/ImperativeAppConfig.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/ImperativeAppConfig.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 
 import org.springframework.boot.ApplicationRunner;
@@ -50,11 +49,6 @@ class ImperativeAppConfig {
 	static final String NFQ_TOPIC = "dtant-topic-i";
 	static final String FQ_TOPIC = "persistent://my-tenant-i/my-namespace-i/dtant-topic-i";
 	static final String MSG_PREFIX = "DefaultTenantNamespace-i:";
-
-	@Bean
-	PulsarTopicBuilder topicBuilder() {
-		return new PulsarTopicBuilder(TopicDomain.persistent, TENANT, NAMESPACE);
-	}
 
 	@Bean
 	PulsarProducerFactory<Object> pulsarProducerFactory(PulsarClient pulsarClient, TopicResolver topicResolver,

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/ReactiveAppConfig.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/ReactiveAppConfig.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
 import org.apache.pulsar.reactive.client.api.ReactivePulsarClient;
 
@@ -52,11 +51,6 @@ class ReactiveAppConfig {
 	static final String NFQ_TOPIC = "dtant-topic-r";
 	static final String FQ_TOPIC = "persistent://my-tenant-r/my-namespace-r/dtant-topic-r";
 	static final String MSG_PREFIX = "DefaultTenantNamespace-r:";
-
-	@Bean
-	PulsarTopicBuilder topicBuilder() {
-		return new PulsarTopicBuilder(TopicDomain.persistent, TENANT, NAMESPACE);
-	}
 
 	@Bean
 	ReactivePulsarSenderFactory<Object> reactivePulsarSenderFactory(ReactivePulsarClient reactivePulsarClient,

--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar-admin.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar-admin.adoc
@@ -31,15 +31,15 @@ The following example shows how to add `PulsarTopic` beans to let the `PulsarAdm
 [source,java,indent=0,subs="verbatim"]
 ----
 @Bean
-PulsarTopic simpleTopic {
+PulsarTopic simpleTopic(PulsarTopicBuilder topicBuilder) {
     // This will create a non-partitioned persistent topic in the 'public/default' tenant/namespace
-    return new PulsarTopicBuilder().name("my-topic").build();
+    return topicBuilder.name("my-topic").build();
 }
 
 @Bean
-PulsarTopic partitionedTopic {
+PulsarTopic partitionedTopic(PulsarTopicBuilder topicBuilder) {
     // This will create a persistent topic with 3 partitions in the provided tenant and namespace
-    return new PulsarTopicBuilder()
+    return topicBuilder
         .name("persistent://my-tenant/my-namespace/partitioned-topic")
         .numberOfPartitions(3)
         .build();

--- a/spring-pulsar-sample-apps/sample-failover-custom-router/build.gradle
+++ b/spring-pulsar-sample-apps/sample-failover-custom-router/build.gradle
@@ -25,8 +25,6 @@ dependencies {
 	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 	implementation 'io.zipkin.reporter2:zipkin-sender-urlconnection'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
-	// TODO remove when new PulsarTopicBuilder published
-	implementation project(':spring-pulsar')
 	testImplementation project(':spring-pulsar-test')
 	testRuntimeOnly 'ch.qos.logback:logback-classic'
 	testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/spring-pulsar-sample-apps/sample-failover-custom-router/src/main/java/com/example/FailoverConsumerApp.java
+++ b/spring-pulsar-sample-apps/sample-failover-custom-router/src/main/java/com/example/FailoverConsumerApp.java
@@ -45,8 +45,8 @@ public class FailoverConsumerApp {
 	}
 
 	@Bean
-	PulsarTopic failoverDemoTopic() {
-		return new PulsarTopicBuilder().name(TOPIC).numberOfPartitions(3).build();
+	PulsarTopic failoverDemoTopic(PulsarTopicBuilder topicBuilder) {
+		return topicBuilder.name(TOPIC).numberOfPartitions(3).build();
 	}
 
 	@Bean

--- a/spring-pulsar-sample-apps/sample-imperative-produce-consume/build.gradle
+++ b/spring-pulsar-sample-apps/sample-imperative-produce-consume/build.gradle
@@ -21,8 +21,6 @@ ext['pulsar.version'] = "${pulsarVersion}"
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-pulsar'
 	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
-	// TODO remove when new PulsarTopicBuilder published
-	implementation project(':spring-pulsar')
 	implementation(testFixtures(project(":spring-pulsar")))
 	implementation project(':spring-pulsar-test')
 	testRuntimeOnly 'ch.qos.logback:logback-classic'

--- a/spring-pulsar-sample-apps/sample-imperative-produce-consume/src/main/java/com/example/ImperativeProduceAndConsumeApp.java
+++ b/spring-pulsar-sample-apps/sample-imperative-produce-consume/src/main/java/com/example/ImperativeProduceAndConsumeApp.java
@@ -98,8 +98,8 @@ public class ImperativeProduceAndConsumeApp {
 		private static final String TOPIC = "produce-consume-partitions";
 
 		@Bean
-		PulsarTopic partitionedTopic() {
-			return new PulsarTopicBuilder().name(TOPIC).numberOfPartitions(3).build();
+		PulsarTopic partitionedTopic(PulsarTopicBuilder topicBuilder) {
+			return topicBuilder.name(TOPIC).numberOfPartitions(3).build();
 		}
 
 		@Bean


### PR DESCRIPTION
Now that Spring Boot `3.4.0-M2` auto-configures the `PulsarTopicBuilder`, we want to update usage for ITs, samples, and docs accordingly.