### PR TITLE
Move default subscription type to factory

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar/message-consumption.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar/message-consumption.adoc
@@ -15,9 +15,6 @@ Spring Boot provides this consumer factory which you can further configure by sp
 
 TIP: The `spring.pulsar.consumer.subscription.name` property is ignored and is instead generated when not specified on the annotation.
 
-TIP: The `spring.pulsar.consumer.subscription.type` property is ignored and is instead taken from the value on the annotation. However, you can set the `subscriptionType = {}` on the annotation to instead use the property value as the default.
-
-
 Let us revisit the `PulsarListener` code snippet we saw in the quick-tour section:
 
 [source, java]

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/DefaultReactivePulsarListenerContainerFactory.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/DefaultReactivePulsarListenerContainerFactory.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
 
 import org.springframework.core.log.LogAccessor;
 import org.springframework.pulsar.reactive.core.ReactivePulsarConsumerFactory;
@@ -87,6 +88,7 @@ public class DefaultReactivePulsarListenerContainerFactory<T> implements Reactiv
 		ReactivePulsarContainerProperties<T> properties = new ReactivePulsarContainerProperties<>();
 		properties.setSchemaResolver(this.getContainerProperties().getSchemaResolver());
 		properties.setTopicResolver(this.getContainerProperties().getTopicResolver());
+		properties.setSubscriptionType(this.getContainerProperties().getSubscriptionType());
 
 		if (!CollectionUtils.isEmpty(endpoint.getTopics())) {
 			properties.setTopics(endpoint.getTopics());
@@ -103,8 +105,9 @@ public class DefaultReactivePulsarListenerContainerFactory<T> implements Reactiv
 		if (endpoint.getSubscriptionType() != null) {
 			properties.setSubscriptionType(endpoint.getSubscriptionType());
 		}
-		else {
-			properties.setSubscriptionType(this.containerProperties.getSubscriptionType());
+		// Default to Exclusive if not set on container props or endpoint
+		if (properties.getSubscriptionType() == null) {
+			properties.setSubscriptionType(SubscriptionType.Exclusive);
 		}
 
 		if (endpoint.getSchemaType() != null) {

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListener.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListener.java
@@ -79,7 +79,7 @@ public @interface ReactivePulsarListener {
 	 * @return single element array with the subscription type or empty array to indicate
 	 * no type chosen by user
 	 */
-	SubscriptionType[] subscriptionType() default { SubscriptionType.Exclusive };
+	SubscriptionType[] subscriptionType() default {};
 
 	/**
 	 * Pulsar schema type for this listener.

--- a/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/config/DefaultReactivePulsarListenerContainerFactoryTests.java
+++ b/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/config/DefaultReactivePulsarListenerContainerFactoryTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.reactive.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.pulsar.reactive.core.ReactivePulsarConsumerFactory;
+import org.springframework.pulsar.reactive.listener.ReactivePulsarContainerProperties;
+
+/**
+ * Unit tests for {@link DefaultReactivePulsarListenerContainerFactory}.
+ */
+class DefaultReactivePulsarListenerContainerFactoryTests {
+
+	@SuppressWarnings("unchecked")
+	@Nested
+	class SubscriptionTypeFrom {
+
+		@Test
+		void factoryPropsUsedWhenNotSetOnEndpoint() {
+			var factoryProps = new ReactivePulsarContainerProperties<String>();
+			factoryProps.setSubscriptionType(SubscriptionType.Shared);
+			var containerFactory = new DefaultReactivePulsarListenerContainerFactory<String>(
+					mock(ReactivePulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(ReactivePulsarListenerEndpoint.class);
+			when(endpoint.getConcurrency()).thenReturn(1);
+			var createdContainer = containerFactory.createListenerContainer(endpoint);
+			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
+				.isEqualTo(SubscriptionType.Shared);
+		}
+
+		@Test
+		void endpointTakesPrecedenceOverFactoryProps() {
+			var factoryProps = new ReactivePulsarContainerProperties<String>();
+			factoryProps.setSubscriptionType(SubscriptionType.Shared);
+			var containerFactory = new DefaultReactivePulsarListenerContainerFactory<String>(
+					mock(ReactivePulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(ReactivePulsarListenerEndpoint.class);
+			when(endpoint.getConcurrency()).thenReturn(1);
+			when(endpoint.getSubscriptionType()).thenReturn(SubscriptionType.Failover);
+			var createdContainer = containerFactory.createListenerContainer(endpoint);
+			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
+				.isEqualTo(SubscriptionType.Failover);
+		}
+
+		@Test
+		void defaultUsedWhenNotSetOnEndpointNorFactoryProps() {
+			var factoryProps = new ReactivePulsarContainerProperties<String>();
+			var containerFactory = new DefaultReactivePulsarListenerContainerFactory<String>(
+					mock(ReactivePulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(ReactivePulsarListenerEndpoint.class);
+			when(endpoint.getConcurrency()).thenReturn(1);
+			var createdContainer = containerFactory.createListenerContainer(endpoint);
+			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
+				.isEqualTo(SubscriptionType.Exclusive);
+
+		}
+
+	}
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
@@ -81,7 +81,7 @@ public @interface PulsarListener {
 	 * @return single element array with the subscription type or empty array to indicate
 	 * no type chosen by user
 	 */
-	SubscriptionType[] subscriptionType() default { SubscriptionType.Exclusive };
+	SubscriptionType[] subscriptionType() default {};
 
 	/**
 	 * Pulsar schema type for this listener.

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactory.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 
+import org.apache.pulsar.client.api.SubscriptionType;
+
 import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.listener.ConcurrentPulsarMessageListenerContainer;
 import org.springframework.pulsar.listener.PulsarContainerProperties;
@@ -74,6 +76,7 @@ public class ConcurrentPulsarListenerContainerFactory<T>
 		PulsarContainerProperties properties = new PulsarContainerProperties();
 		properties.setSchemaResolver(this.getContainerProperties().getSchemaResolver());
 		properties.setTopicResolver(this.getContainerProperties().getTopicResolver());
+		properties.setSubscriptionType(this.getContainerProperties().getSubscriptionType());
 
 		var parentTxnProps = this.getContainerProperties().transactions();
 		var childTxnProps = properties.transactions();
@@ -101,6 +104,10 @@ public class ConcurrentPulsarListenerContainerFactory<T>
 
 		if (endpoint.getSubscriptionType() != null) {
 			properties.setSubscriptionType(endpoint.getSubscriptionType());
+		}
+		// Default to Exclusive if not set on container props or endpoint
+		if (properties.getSubscriptionType() == null) {
+			properties.setSubscriptionType(SubscriptionType.Exclusive);
 		}
 
 		properties.setSchemaType(endpoint.getSchemaType());

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
@@ -304,11 +304,9 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 						topicNames, this.containerProperties.getSubscriptionName(), properties, customizers);
 				Assert.state(this.consumer != null, "Unable to create a consumer");
 
-				// If subtype is null - update it based on the actual subtype of the
-				// underlying consumer
-				if (this.subscriptionType == null) {
-					updateSubscriptionTypeFromConsumer(this.consumer);
-				}
+				// Update sub type from underlying consumer as customizer from annotation
+				// may have updated it
+				updateSubscriptionTypeFromConsumer(this.consumer);
 			}
 			catch (PulsarException e) {
 				DefaultPulsarMessageListenerContainer.this.logger.error(e, () -> "Pulsar exception.");

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
@@ -212,6 +212,51 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 			Consumer<String> consumer, ConcurrentPulsarMessageListenerContainer<String> concurrentContainer) {
 	}
 
+	@SuppressWarnings("unchecked")
+	@Nested
+	class SubscriptionTypeFrom {
+
+		@Test
+		void factoryPropsUsedWhenNotSetOnEndpoint() {
+			var factoryProps = new PulsarContainerProperties();
+			factoryProps.setSubscriptionType(SubscriptionType.Shared);
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
+			when(endpoint.getConcurrency()).thenReturn(1);
+			var createdContainer = containerFactory.createListenerContainer(endpoint);
+			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
+				.isEqualTo(SubscriptionType.Shared);
+		}
+
+		@Test
+		void endpointTakesPrecedenceOverFactoryProps() {
+			var factoryProps = new PulsarContainerProperties();
+			factoryProps.setSubscriptionType(SubscriptionType.Shared);
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
+			when(endpoint.getConcurrency()).thenReturn(1);
+			when(endpoint.getSubscriptionType()).thenReturn(SubscriptionType.Failover);
+			var createdContainer = containerFactory.createListenerContainer(endpoint);
+			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
+				.isEqualTo(SubscriptionType.Failover);
+		}
+
+		@Test
+		void defaultUsedWhenNotSetOnEndpointNorFactoryProps() {
+			var factoryProps = new PulsarContainerProperties();
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
+			when(endpoint.getConcurrency()).thenReturn(1);
+			var createdContainer = containerFactory.createListenerContainer(endpoint);
+			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
+				.isEqualTo(SubscriptionType.Exclusive);
+		}
+
+	}
+
 	@Nested
 	class ObservationConfigurationTests {
 


### PR DESCRIPTION
This commit moves the default subscription type from the `@PulsarListener` annotation to the container factory (props) which allows the `spring.pulsar.consumer.subscription-type` config prop to be respected.

See https://github.com/spring-projects/spring-boot/issues/42053

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
