### PR TITLE
Move default subscription name to factory

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar/message-consumption.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar/message-consumption.adoc
@@ -11,9 +11,6 @@ When you use Spring Boot support, it automatically enables this annotation and c
 `PulsarMessageListenerContainer` uses a `PulsarConsumerFactory` to create and manage the Pulsar consumer the underlying Pulsar consumer that it uses to consume messages.
 
 Spring Boot provides this consumer factory which you can further configure by specifying the {spring-boot-pulsar-config-props}[`spring.pulsar.consumer.*`] application properties.
-**Most** of the configured properties on the factory will be respected in the listener with the following **exceptions**:
-
-TIP: The `spring.pulsar.consumer.subscription.name` property is ignored and is instead generated when not specified on the annotation.
 
 Let us revisit the `PulsarListener` code snippet we saw in the quick-tour section:
 

--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/reactive-pulsar/reactive-message-consumption.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/reactive-pulsar/reactive-message-consumption.adoc
@@ -118,11 +118,6 @@ NOTE: There is no support for using `org.apache.pulsar.client.api.Messages<T>` i
 === Configuration - Application Properties
 The listener relies on the `ReactivePulsarConsumerFactory` to create and manage the underlying Pulsar consumer that it uses to consume messages.
 Spring Boot provides this consumer factory which you can further configure by specifying the {spring-boot-pulsar-config-props}[`spring.pulsar.consumer.*`] application properties.
-**Most** of the configured properties on the factory will be respected in the listener with the following **exceptions**:
-
-TIP: The `spring.pulsar.consumer.subscription.name` property is ignored and is instead generated when not specified on the annotation.
-
-TIP: The `spring.pulsar.consumer.subscription.type` property is ignored and is instead taken from the value on the annotation. However, you can set the `subscriptionType = {}` on the annotation to instead use the property value as the default.
 
 === Generic records with AUTO_CONSUME
 If there is no chance to know the type of schema of a Pulsar topic in advance, you can use the `AUTO_CONSUME` schema type to consume generic records.

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
@@ -214,10 +214,10 @@ public class PulsarListenerAnnotationBeanPostProcessor<V> extends AbstractPulsar
 			PulsarListener pulsarListener, Object bean, String[] topics, String topicPattern) {
 		endpoint.setBean(bean);
 		endpoint.setMessageHandlerMethodFactory(this.messageHandlerMethodFactory);
-		endpoint.setSubscriptionName(getEndpointSubscriptionName(pulsarListener));
 		endpoint.setId(getEndpointId(pulsarListener));
 		endpoint.setTopics(topics);
 		endpoint.setTopicPattern(topicPattern);
+		resolveSubscriptionName(endpoint, pulsarListener);
 		resolveSubscriptionType(endpoint, pulsarListener);
 		endpoint.setSchemaType(pulsarListener.schemaType());
 		endpoint.setAckMode(pulsarListener.ackMode());
@@ -249,6 +249,13 @@ public class PulsarListenerAnnotationBeanPostProcessor<V> extends AbstractPulsar
 				() -> "PulsarListener.subscriptionType must have 0 or 1 elements");
 		if (pulsarListener.subscriptionType().length == 1) {
 			endpoint.setSubscriptionType(pulsarListener.subscriptionType()[0]);
+		}
+	}
+
+	private void resolveSubscriptionName(MethodPulsarListenerEndpoint<?> endpoint, PulsarListener pulsarListener) {
+		if (StringUtils.hasText(pulsarListener.subscriptionName())) {
+			endpoint
+				.setSubscriptionName(resolveExpressionAsString(pulsarListener.subscriptionName(), "subscriptionName"));
 		}
 	}
 
@@ -383,13 +390,6 @@ public class PulsarListenerAnnotationBeanPostProcessor<V> extends AbstractPulsar
 			}
 			endpoint.setConsumerProperties(properties);
 		}
-	}
-
-	private String getEndpointSubscriptionName(PulsarListener pulsarListener) {
-		if (StringUtils.hasText(pulsarListener.subscriptionName())) {
-			return resolveExpressionAsString(pulsarListener.subscriptionName(), "subscriptionName");
-		}
-		return GENERATED_ID_PREFIX + this.counter.getAndIncrement();
 	}
 
 	private String getEndpointId(PulsarListener pulsarListener) {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/PulsarListenerEndpointRegistrar.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/PulsarListenerEndpointRegistrar.java
@@ -118,7 +118,7 @@ public class PulsarListenerEndpointRegistrar implements BeanFactoryAware, Initia
 
 	public void registerEndpoint(ListenerEndpoint endpoint, @Nullable ListenerContainerFactory<?, ?> factory) {
 		Assert.notNull(endpoint, "Endpoint must be set");
-		Assert.hasText(endpoint.getSubscriptionName(), "Endpoint id must be set");
+		Assert.hasText(endpoint.getId(), "Endpoint id must be set");
 		// Factory may be null, we defer the resolution right before actually creating the
 		// container
 		PulsarListenerEndpointDescriptor descriptor = new PulsarListenerEndpointDescriptor(endpoint, factory);

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactoryTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.pulsar.reactive.config;
+package org.springframework.pulsar.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -24,13 +24,13 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.pulsar.reactive.core.ReactivePulsarConsumerFactory;
-import org.springframework.pulsar.reactive.listener.ReactivePulsarContainerProperties;
+import org.springframework.pulsar.core.PulsarConsumerFactory;
+import org.springframework.pulsar.listener.PulsarContainerProperties;
 
 /**
- * Unit tests for {@link DefaultReactivePulsarListenerContainerFactory}.
+ * Unit tests for {@link ConcurrentPulsarListenerContainerFactory}.
  */
-class DefaultReactivePulsarListenerContainerFactoryTests {
+class ConcurrentPulsarListenerContainerFactoryTests {
 
 	@SuppressWarnings("unchecked")
 	@Nested
@@ -38,11 +38,11 @@ class DefaultReactivePulsarListenerContainerFactoryTests {
 
 		@Test
 		void factoryPropsUsedWhenNotSetOnEndpoint() {
-			var factoryProps = new ReactivePulsarContainerProperties<String>();
+			var factoryProps = new PulsarContainerProperties();
 			factoryProps.setSubscriptionType(SubscriptionType.Shared);
-			var containerFactory = new DefaultReactivePulsarListenerContainerFactory<String>(
-					mock(ReactivePulsarConsumerFactory.class), factoryProps);
-			var endpoint = mock(ReactivePulsarListenerEndpoint.class);
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
 			when(endpoint.getConcurrency()).thenReturn(1);
 			var createdContainer = containerFactory.createListenerContainer(endpoint);
 			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
@@ -51,11 +51,11 @@ class DefaultReactivePulsarListenerContainerFactoryTests {
 
 		@Test
 		void endpointTakesPrecedenceOverFactoryProps() {
-			var factoryProps = new ReactivePulsarContainerProperties<String>();
+			var factoryProps = new PulsarContainerProperties();
 			factoryProps.setSubscriptionType(SubscriptionType.Shared);
-			var containerFactory = new DefaultReactivePulsarListenerContainerFactory<String>(
-					mock(ReactivePulsarConsumerFactory.class), factoryProps);
-			var endpoint = mock(ReactivePulsarListenerEndpoint.class);
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
 			when(endpoint.getConcurrency()).thenReturn(1);
 			when(endpoint.getSubscriptionType()).thenReturn(SubscriptionType.Failover);
 			var createdContainer = containerFactory.createListenerContainer(endpoint);
@@ -65,15 +65,14 @@ class DefaultReactivePulsarListenerContainerFactoryTests {
 
 		@Test
 		void defaultUsedWhenNotSetOnEndpointNorFactoryProps() {
-			var factoryProps = new ReactivePulsarContainerProperties<String>();
-			var containerFactory = new DefaultReactivePulsarListenerContainerFactory<String>(
-					mock(ReactivePulsarConsumerFactory.class), factoryProps);
-			var endpoint = mock(ReactivePulsarListenerEndpoint.class);
+			var factoryProps = new PulsarContainerProperties();
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
 			when(endpoint.getConcurrency()).thenReturn(1);
 			var createdContainer = containerFactory.createListenerContainer(endpoint);
 			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
 				.isEqualTo(SubscriptionType.Exclusive);
-
 		}
 
 	}
@@ -84,11 +83,11 @@ class DefaultReactivePulsarListenerContainerFactoryTests {
 
 		@Test
 		void factoryPropsUsedWhenNotSetOnEndpoint() {
-			var factoryProps = new ReactivePulsarContainerProperties<String>();
+			var factoryProps = new PulsarContainerProperties();
 			factoryProps.setSubscriptionName("my-factory-subscription");
-			var containerFactory = new DefaultReactivePulsarListenerContainerFactory<String>(
-					mock(ReactivePulsarConsumerFactory.class), factoryProps);
-			var endpoint = mock(ReactivePulsarListenerEndpoint.class);
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
 			when(endpoint.getConcurrency()).thenReturn(1);
 			var createdContainer = containerFactory.createListenerContainer(endpoint);
 			assertThat(createdContainer.getContainerProperties().getSubscriptionName())
@@ -97,11 +96,11 @@ class DefaultReactivePulsarListenerContainerFactoryTests {
 
 		@Test
 		void endpointTakesPrecedenceOverFactoryProps() {
-			var factoryProps = new ReactivePulsarContainerProperties<String>();
+			var factoryProps = new PulsarContainerProperties();
 			factoryProps.setSubscriptionName("my-factory-subscription");
-			var containerFactory = new DefaultReactivePulsarListenerContainerFactory<String>(
-					mock(ReactivePulsarConsumerFactory.class), factoryProps);
-			var endpoint = mock(ReactivePulsarListenerEndpoint.class);
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
 			when(endpoint.getConcurrency()).thenReturn(1);
 			when(endpoint.getSubscriptionName()).thenReturn("my-endpoint-subscription");
 			var createdContainer = containerFactory.createListenerContainer(endpoint);
@@ -111,18 +110,18 @@ class DefaultReactivePulsarListenerContainerFactoryTests {
 
 		@Test
 		void defaultUsedWhenNotSetOnEndpointNorFactoryProps() {
-			var factoryProps = new ReactivePulsarContainerProperties<String>();
-			var containerFactory = new DefaultReactivePulsarListenerContainerFactory<String>(
-					mock(ReactivePulsarConsumerFactory.class), factoryProps);
-			var endpoint = mock(ReactivePulsarListenerEndpoint.class);
+			var factoryProps = new PulsarContainerProperties();
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
 			when(endpoint.getConcurrency()).thenReturn(1);
 
 			var container1 = containerFactory.createListenerContainer(endpoint);
 			assertThat(container1.getContainerProperties().getSubscriptionName())
-				.startsWith("org.springframework.Pulsar.ReactivePulsarListenerEndpointContainer#");
+				.startsWith("org.springframework.Pulsar.PulsarListenerEndpointContainer#");
 			var container2 = containerFactory.createListenerContainer(endpoint);
 			assertThat(container2.getContainerProperties().getSubscriptionName())
-				.startsWith("org.springframework.Pulsar.ReactivePulsarListenerEndpointContainer#");
+				.startsWith("org.springframework.Pulsar.PulsarListenerEndpointContainer#");
 			assertThat(container1.getContainerProperties().getSubscriptionName())
 				.isNotEqualTo(container2.getContainerProperties().getSubscriptionName());
 		}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
@@ -212,51 +212,6 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 			Consumer<String> consumer, ConcurrentPulsarMessageListenerContainer<String> concurrentContainer) {
 	}
 
-	@SuppressWarnings("unchecked")
-	@Nested
-	class SubscriptionTypeFrom {
-
-		@Test
-		void factoryPropsUsedWhenNotSetOnEndpoint() {
-			var factoryProps = new PulsarContainerProperties();
-			factoryProps.setSubscriptionType(SubscriptionType.Shared);
-			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
-					mock(PulsarConsumerFactory.class), factoryProps);
-			var endpoint = mock(PulsarListenerEndpoint.class);
-			when(endpoint.getConcurrency()).thenReturn(1);
-			var createdContainer = containerFactory.createListenerContainer(endpoint);
-			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
-				.isEqualTo(SubscriptionType.Shared);
-		}
-
-		@Test
-		void endpointTakesPrecedenceOverFactoryProps() {
-			var factoryProps = new PulsarContainerProperties();
-			factoryProps.setSubscriptionType(SubscriptionType.Shared);
-			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
-					mock(PulsarConsumerFactory.class), factoryProps);
-			var endpoint = mock(PulsarListenerEndpoint.class);
-			when(endpoint.getConcurrency()).thenReturn(1);
-			when(endpoint.getSubscriptionType()).thenReturn(SubscriptionType.Failover);
-			var createdContainer = containerFactory.createListenerContainer(endpoint);
-			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
-				.isEqualTo(SubscriptionType.Failover);
-		}
-
-		@Test
-		void defaultUsedWhenNotSetOnEndpointNorFactoryProps() {
-			var factoryProps = new PulsarContainerProperties();
-			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
-					mock(PulsarConsumerFactory.class), factoryProps);
-			var endpoint = mock(PulsarListenerEndpoint.class);
-			when(endpoint.getConcurrency()).thenReturn(1);
-			var createdContainer = containerFactory.createListenerContainer(endpoint);
-			assertThat(createdContainer.getContainerProperties().getSubscriptionType())
-				.isEqualTo(SubscriptionType.Exclusive);
-		}
-
-	}
-
 	@Nested
 	class ObservationConfigurationTests {
 


### PR DESCRIPTION
This commit moves the default subscription name from the `@PulsarListener` annotation to the container factory (props) which allows the `spring.pulsar.consumer.subscription.name` config prop to be respected.

See https://github.com/spring-projects/spring-boot/issues/42053

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
