### PR TITLE
Add startup failure policy to listeners

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/DefaultReactivePulsarMessageListenerContainer.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/DefaultReactivePulsarMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springframework.pulsar.reactive.listener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -29,6 +31,8 @@ import org.apache.pulsar.reactive.client.api.ReactiveMessagePipelineBuilder.Conc
 import org.apache.pulsar.reactive.client.internal.api.ApiImplementationFactory;
 
 import org.springframework.core.log.LogAccessor;
+import org.springframework.pulsar.PulsarException;
+import org.springframework.pulsar.config.StartupFailurePolicy;
 import org.springframework.pulsar.reactive.core.ReactiveMessageConsumerBuilderCustomizer;
 import org.springframework.pulsar.reactive.core.ReactivePulsarConsumerFactory;
 import org.springframework.util.CollectionUtils;
@@ -38,6 +42,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @param <T> message type.
  * @author Christophe Bornet
+ * @author Chris Bono
  */
 public non-sealed class DefaultReactivePulsarMessageListenerContainer<T>
 		implements ReactivePulsarMessageListenerContainer<T> {
@@ -135,13 +140,56 @@ public non-sealed class DefaultReactivePulsarMessageListenerContainer<T>
 
 	private void doStart() {
 		setRunning(true);
-		this.pipeline = startPipeline(this.pulsarContainerProperties);
+		var containerProps = this.getContainerProperties();
+		try {
+			this.pipeline = startPipeline(this.pulsarContainerProperties);
+		}
+		catch (Exception e) {
+			this.logger.error(e, () -> "Error starting Reactive pipeline");
+			this.doStop();
+			if (containerProps.getStartupFailurePolicy() == StartupFailurePolicy.STOP) {
+				this.logger.info(() -> "Configured to stop on startup failures - exiting");
+				throw new IllegalStateException("Error starting Reactive pipeline", e);
+			}
+		}
+		// Pipeline started w/o errors - short circuit
+		if (this.pipeline != null && this.pipeline.isRunning()) {
+			return;
+		}
+
+		if (containerProps.getStartupFailurePolicy() == StartupFailurePolicy.RETRY) {
+			this.logger.info(() -> "Configured to retry on startup failures - retrying");
+			CompletableFuture.supplyAsync(() -> {
+				var retryTemplate = Optional.ofNullable(containerProps.getStartupFailureRetryTemplate())
+					.orElseGet(containerProps::getDefaultStartupFailureRetryTemplate);
+				ReactiveMessagePipeline pipeline = null;
+				try {
+					pipeline = retryTemplate
+						.<ReactiveMessagePipeline, PulsarException>execute((__) -> startPipeline(containerProps));
+				}
+				catch (PulsarException ex) {
+					this.logger.error(ex, () -> "Unable to start Reactive pipeline - retries exhausted");
+					this.doStop();
+				}
+				return pipeline;
+			}).whenComplete((p, e) -> {
+				this.pipeline = p;
+				setRunning(this.pipeline != null ? this.pipeline.isRunning() : false);
+				if (e != null && !(e instanceof PulsarException)) {
+					// PulsarException handled in supplyAsync handler above
+					this.logger.error(e, () -> "Unable to start Reactive pipeline");
+					this.doStop();
+				}
+			});
+		}
 	}
 
 	public void doStop() {
 		try {
 			this.logger.info("Closing Pulsar Reactive pipeline.");
-			this.pipeline.close();
+			if (this.pipeline != null) {
+				this.pipeline.close();
+			}
 		}
 		catch (Exception e) {
 			this.logger.error(e, () -> "Error closing Pulsar Reactive pipeline.");
@@ -174,6 +222,9 @@ public non-sealed class DefaultReactivePulsarMessageListenerContainer<T>
 			customizers.add(this.consumerCustomizer);
 		}
 
+		// NOTE: The following various pipeline builders always set 'pipelineRetrySpec'
+		// to null as the container controls the retry of the pipeline start. Otherwise
+		// they do not work well together.
 		ReactiveMessageConsumer<T> consumer = getReactivePulsarConsumerFactory()
 			.createConsumer(containerProperties.getSchema(), customizers);
 		ReactiveMessagePipelineBuilder<T> pipelineBuilder = ApiImplementationFactory
@@ -183,6 +234,7 @@ public non-sealed class DefaultReactivePulsarMessageListenerContainer<T>
 		if (messageHandler instanceof ReactivePulsarStreamingHandler<?>) {
 			pipeline = pipelineBuilder
 				.streamingMessageHandler(((ReactivePulsarStreamingHandler<T>) messageHandler)::received)
+				.pipelineRetrySpec(null)
 				.build();
 		}
 		else {
@@ -195,10 +247,10 @@ public non-sealed class DefaultReactivePulsarMessageListenerContainer<T>
 				if (containerProperties.isUseKeyOrderedProcessing()) {
 					concurrentPipelineBuilder.useKeyOrderedProcessing();
 				}
-				pipeline = concurrentPipelineBuilder.build();
+				pipeline = concurrentPipelineBuilder.pipelineRetrySpec(null).build();
 			}
 			else {
-				pipeline = pipelineBuilder.build();
+				pipeline = pipelineBuilder.pipelineRetrySpec(null).build();
 			}
 		}
 		pipeline.start();

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/ReactivePulsarContainerProperties.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/ReactivePulsarContainerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,20 @@ package org.springframework.pulsar.reactive.listener;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.schema.SchemaType;
 
+import org.springframework.lang.Nullable;
+import org.springframework.pulsar.config.StartupFailurePolicy;
 import org.springframework.pulsar.core.DefaultSchemaResolver;
 import org.springframework.pulsar.core.DefaultTopicResolver;
 import org.springframework.pulsar.core.SchemaResolver;
 import org.springframework.pulsar.core.TopicResolver;
+import org.springframework.retry.support.RetryTemplate;
 
 /**
  * Contains runtime properties for a reactive listener container.
@@ -60,6 +64,16 @@ public class ReactivePulsarContainerProperties<T> {
 	private int concurrency = 0;
 
 	private boolean useKeyOrderedProcessing = false;
+
+	@Nullable
+	private RetryTemplate startupFailureRetryTemplate;
+
+	private final RetryTemplate defaultStartupFailureRetryTemplate = RetryTemplate.builder()
+		.maxAttempts(3)
+		.fixedBackoff(Duration.ofSeconds(10))
+		.build();
+
+	private StartupFailurePolicy startupFailurePolicy = StartupFailurePolicy.STOP;
 
 	public ReactivePulsarMessageHandler getMessageHandler() {
 		return this.messageHandler;
@@ -159,6 +173,48 @@ public class ReactivePulsarContainerProperties<T> {
 
 	public void setUseKeyOrderedProcessing(boolean useKeyOrderedProcessing) {
 		this.useKeyOrderedProcessing = useKeyOrderedProcessing;
+	}
+
+	@Nullable
+	public RetryTemplate getStartupFailureRetryTemplate() {
+		return this.startupFailureRetryTemplate;
+	}
+
+	/**
+	 * Get the default template to use to retry startup when no custom retry template has
+	 * been specified.
+	 * @return the default retry template that will retry 3 times with a fixed delay of 10
+	 * seconds between each attempt.
+	 * @since 1.2.0
+	 */
+	public RetryTemplate getDefaultStartupFailureRetryTemplate() {
+		return this.defaultStartupFailureRetryTemplate;
+	}
+
+	/**
+	 * Set the template to use to retry startup when an exception occurs during startup.
+	 * @param startupFailureRetryTemplate the retry template to use
+	 * @since 1.2.0
+	 */
+	public void setStartupFailureRetryTemplate(RetryTemplate startupFailureRetryTemplate) {
+		this.startupFailureRetryTemplate = startupFailureRetryTemplate;
+		if (this.startupFailureRetryTemplate != null) {
+			setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+		}
+	}
+
+	public StartupFailurePolicy getStartupFailurePolicy() {
+		return this.startupFailurePolicy;
+	}
+
+	/**
+	 * The action to take on the container when a failure occurs during startup.
+	 * @param startupFailurePolicy action to take when a failure occurs during startup
+	 * @since 1.2.0
+	 */
+	public void setStartupFailurePolicy(StartupFailurePolicy startupFailurePolicy) {
+		this.startupFailurePolicy = Objects.requireNonNull(startupFailurePolicy,
+				"startupFailurePolicy must not be null");
 	}
 
 }

--- a/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/DefaultReactivePulsarMessageListenerContainerTests.java
+++ b/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/DefaultReactivePulsarMessageListenerContainerTests.java
@@ -17,11 +17,22 @@
 package org.springframework.pulsar.reactive.listener;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.pulsar.client.api.DeadLetterPolicy;
@@ -35,10 +46,15 @@ import org.apache.pulsar.reactive.client.api.MessageSpec;
 import org.apache.pulsar.reactive.client.api.ReactiveMessagePipeline;
 import org.apache.pulsar.reactive.client.api.ReactivePulsarClient;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.core.log.LogAccessor;
+import org.springframework.pulsar.PulsarException;
+import org.springframework.pulsar.config.StartupFailurePolicy;
+import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
 import org.springframework.pulsar.core.JSONSchemaUtil;
+import org.springframework.pulsar.core.PulsarTemplate;
 import org.springframework.pulsar.reactive.core.DefaultReactivePulsarConsumerFactory;
 import org.springframework.pulsar.reactive.core.DefaultReactivePulsarSenderFactory;
 import org.springframework.pulsar.reactive.core.ReactiveMessageConsumerBuilderCustomizer;
@@ -46,6 +62,10 @@ import org.springframework.pulsar.reactive.core.ReactivePulsarTemplate;
 import org.springframework.pulsar.test.model.UserRecord;
 import org.springframework.pulsar.test.model.json.UserRecordObjectMapper;
 import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.retry.support.RetryTemplate;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -384,6 +404,169 @@ class DefaultReactivePulsarMessageListenerContainerTests implements PulsarTestCo
 		catch (Exception ex) {
 			logger.warn(ex, "Failed to stop container %s: %s".formatted(container, ex.getMessage()));
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nested
+	class WithStartupFailures {
+
+		// @Test
+		void whenPolicyIsStopThenExceptionIsThrown() throws Exception {
+			DefaultReactivePulsarConsumerFactory<String> consumerFactory = mock(
+					DefaultReactivePulsarConsumerFactory.class);
+			var containerProps = new ReactivePulsarContainerProperties<String>();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.STOP);
+			containerProps.setSchema(Schema.STRING);
+			containerProps
+				.setMessageHandler((ReactivePulsarOneByOneMessageHandler<String>) (msg) -> Mono.fromRunnable(() -> {
+				}));
+			var container = new DefaultReactivePulsarMessageListenerContainer<>(consumerFactory, containerProps);
+			// setup factory to throw ex when create consumer
+			var failCause = new PulsarException("please-stop");
+			when(consumerFactory.createConsumer(any(), any())).thenThrow(failCause);
+			// start container and expect ex thrown
+			assertThatIllegalStateException().isThrownBy(() -> container.start())
+				.withMessageStartingWith("Error starting Reactive pipeline")
+				.withCause(failCause);
+			assertThat(container.isRunning()).isFalse();
+		}
+
+		// @Test
+		void whenPolicyIsContinueThenExceptionIsNotThrown() throws Exception {
+			DefaultReactivePulsarConsumerFactory<String> consumerFactory = mock(
+					DefaultReactivePulsarConsumerFactory.class);
+			var containerProps = new ReactivePulsarContainerProperties<String>();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.CONTINUE);
+			containerProps.setSchema(Schema.STRING);
+			containerProps
+				.setMessageHandler((ReactivePulsarOneByOneMessageHandler<String>) (msg) -> Mono.fromRunnable(() -> {
+				}));
+			var container = new DefaultReactivePulsarMessageListenerContainer<>(consumerFactory, containerProps);
+			// setup factory to throw ex when create consumer
+			var failCause = new PulsarException("please-continue");
+			when(consumerFactory.createConsumer(any(), any())).thenThrow(failCause);
+			// start container and expect ex thrown
+			container.start();
+			assertThat(container.isRunning()).isFalse();
+		}
+
+		// @Test
+		void whenPolicyIsRetryAndRetriesAreExhaustedThenContainerDoesNotStart() throws Exception {
+			DefaultReactivePulsarConsumerFactory<String> consumerFactory = mock(
+					DefaultReactivePulsarConsumerFactory.class);
+			var retryCount = new AtomicInteger(0);
+			var thrown = new ArrayList<Throwable>();
+			var retryListener = new RetryListener() {
+				@Override
+				public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					retryCount.set(context.getRetryCount());
+				}
+
+				@Override
+				public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					thrown.add(throwable);
+				}
+			};
+			var retryTemplate = RetryTemplate.builder()
+				.maxAttempts(2)
+				.fixedBackoff(Duration.ofSeconds(1))
+				.withListener(retryListener)
+				.build();
+			var containerProps = new ReactivePulsarContainerProperties<String>();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+			containerProps.setStartupFailureRetryTemplate(retryTemplate);
+			containerProps.setSchema(Schema.STRING);
+			containerProps
+				.setMessageHandler((ReactivePulsarOneByOneMessageHandler<String>) (msg) -> Mono.fromRunnable(() -> {
+				}));
+			var container = new DefaultReactivePulsarMessageListenerContainer<>(consumerFactory, containerProps);
+			// setup factory to throw ex when create consumer
+			var failCause = new PulsarException("please-retry-exhausted");
+			doThrow(failCause).doThrow(failCause).doThrow(failCause).when(consumerFactory).createConsumer(any(), any());
+			// start container and expect ex not thrown and 2 retries
+			container.start();
+			await().atMost(Duration.ofSeconds(15)).until(() -> retryCount.get() == 2);
+			assertThat(thrown).containsExactly(failCause, failCause);
+			assertThat(container.isRunning()).isFalse();
+			// factory called 3x (initial + 2 retries)
+			verify(consumerFactory, times(3)).createConsumer(any(), any());
+		}
+
+		// @Test
+		void whenPolicyIsRetryAndRetryIsSuccessfulThenContainerStarts() throws Exception {
+			var pulsarClient = PulsarClient.builder()
+				.serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl())
+				.build();
+			ReactivePulsarMessageListenerContainer<String> container = null;
+			try {
+				var reactivePulsarClient = AdaptedReactivePulsarClientFactory.create(pulsarClient);
+				var topic = topicNameForTest("wsf-retry");
+				var subscription = topic + "-sub";
+				var consumerFactory = spy(
+						new DefaultReactivePulsarConsumerFactory<String>(reactivePulsarClient, List.of((cb) -> {
+							cb.topic(topic);
+							cb.subscriptionName(subscription);
+						})));
+				var retryCount = new AtomicInteger(0);
+				var thrown = new ArrayList<Throwable>();
+				var retryListener = new RetryListener() {
+					@Override
+					public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+							Throwable throwable) {
+						retryCount.set(context.getRetryCount());
+					}
+
+					@Override
+					public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+							Throwable throwable) {
+						thrown.add(throwable);
+					}
+				};
+				var retryTemplate = RetryTemplate.builder()
+					.maxAttempts(3)
+					.fixedBackoff(Duration.ofSeconds(1))
+					.withListener(retryListener)
+					.build();
+				var latch = new CountDownLatch(1);
+				var containerProps = new ReactivePulsarContainerProperties<String>();
+				containerProps.setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+				containerProps.setStartupFailureRetryTemplate(retryTemplate);
+				containerProps.setMessageHandler(
+						(ReactivePulsarOneByOneMessageHandler<String>) (msg) -> Mono.fromRunnable(latch::countDown));
+				containerProps.setSchema(Schema.STRING);
+				container = new DefaultReactivePulsarMessageListenerContainer<>(consumerFactory, containerProps);
+
+				// setup factory to throw ex on initial call and 1st retry - then succeed
+				// on
+				// 2nd retry
+				var failCause = new PulsarException("please-retry");
+				doThrow(failCause).doThrow(failCause)
+					.doCallRealMethod()
+					.when(consumerFactory)
+					.createConsumer(any(), any());
+				// start container and expect started after retries
+				container.start();
+				await().atMost(Duration.ofSeconds(240)).until(container::isRunning);
+
+				// factory called 3x (initial call + 2 retries)
+				verify(consumerFactory, times(3)).createConsumer(any(), any());
+				// only had to retry once (2nd call in retry template succeeded)
+				assertThat(retryCount).hasValue(1);
+				assertThat(thrown).containsExactly(failCause);
+				// should be able to process messages
+				var producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient, topic);
+				var pulsarTemplate = new PulsarTemplate<>(producerFactory);
+				pulsarTemplate.sendAsync("hello-" + topic);
+				assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+			}
+			finally {
+				safeStopContainer(container);
+				pulsarClient.close();
+			}
+		}
+
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/StartupFailurePolicy.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/StartupFailurePolicy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.config;
+
+/**
+ * The action to take on the container when a failure occurs during startup.
+ *
+ * @author Chris Bono
+ * @since 1.2.0
+ */
+public enum StartupFailurePolicy {
+
+	/** Stop the container and throw exception. */
+	STOP,
+
+	/** Stop the container but do not throw exception. */
+	CONTINUE,
+
+	/** Retry startup. */
+	RETRY
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.pulsar.listener;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -27,6 +28,7 @@ import org.apache.pulsar.common.schema.SchemaType;
 
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.lang.Nullable;
+import org.springframework.pulsar.config.StartupFailurePolicy;
 import org.springframework.pulsar.core.DefaultSchemaResolver;
 import org.springframework.pulsar.core.DefaultTopicResolver;
 import org.springframework.pulsar.core.SchemaResolver;
@@ -34,6 +36,7 @@ import org.springframework.pulsar.core.TopicResolver;
 import org.springframework.pulsar.core.TransactionProperties;
 import org.springframework.pulsar.observation.PulsarListenerObservationConvention;
 import org.springframework.pulsar.transaction.PulsarAwareTransactionManager;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.util.Assert;
@@ -96,6 +99,16 @@ public class PulsarContainerProperties {
 	private Properties pulsarConsumerProperties = new Properties();
 
 	private final TransactionSettings transactions = new TransactionSettings();
+
+	@Nullable
+	private RetryTemplate startupFailureRetryTemplate;
+
+	private final RetryTemplate defaultStartupFailureRetryTemplate = RetryTemplate.builder()
+		.maxAttempts(3)
+		.fixedBackoff(Duration.ofSeconds(10))
+		.build();
+
+	private StartupFailurePolicy startupFailurePolicy = StartupFailurePolicy.STOP;
 
 	public PulsarContainerProperties(String... topics) {
 		this.topics = Set.of(topics);
@@ -211,7 +224,10 @@ public class PulsarContainerProperties {
 	 * Set the timeout to wait for a consumer thread to start before logging an error.
 	 * Default 30 seconds.
 	 * @param consumerStartTimeout the consumer start timeout.
+	 * @deprecated As of version 1.2.0 startup policy is controlled via
+	 * {@link #getStartupFailurePolicy()}
 	 */
+	@Deprecated(since = "1.2.0", forRemoval = true)
 	public void setConsumerStartTimeout(Duration consumerStartTimeout) {
 		Assert.notNull(consumerStartTimeout, "'consumerStartTimeout' cannot be null");
 		this.consumerStartTimeout = consumerStartTimeout;
@@ -282,12 +298,54 @@ public class PulsarContainerProperties {
 	}
 
 	/**
-	 * Gets the transaction settings.
+	 * Gets the transaction settings for the listener container.
 	 * @return the transaction settings
 	 * @since 1.1.0
 	 */
 	public TransactionSettings transactions() {
 		return this.transactions;
+	}
+
+	@Nullable
+	public RetryTemplate getStartupFailureRetryTemplate() {
+		return this.startupFailureRetryTemplate;
+	}
+
+	/**
+	 * Get the default template to use to retry startup when no custom retry template has
+	 * been specified.
+	 * @return the default retry template that will retry 3 times with a fixed delay of 10
+	 * seconds between each attempt.
+	 * @since 1.2.0
+	 */
+	public RetryTemplate getDefaultStartupFailureRetryTemplate() {
+		return this.defaultStartupFailureRetryTemplate;
+	}
+
+	/**
+	 * Set the template to use to retry startup when an exception occurs during startup.
+	 * @param startupFailureRetryTemplate the retry template to use
+	 * @since 1.2.0
+	 */
+	public void setStartupFailureRetryTemplate(RetryTemplate startupFailureRetryTemplate) {
+		this.startupFailureRetryTemplate = startupFailureRetryTemplate;
+		if (this.startupFailureRetryTemplate != null) {
+			setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+		}
+	}
+
+	public StartupFailurePolicy getStartupFailurePolicy() {
+		return this.startupFailurePolicy;
+	}
+
+	/**
+	 * The action to take on the container when a failure occurs during startup.
+	 * @param startupFailurePolicy action to take when a failure occurs during startup
+	 * @since 1.2.0
+	 */
+	public void setStartupFailurePolicy(StartupFailurePolicy startupFailurePolicy) {
+		this.startupFailurePolicy = Objects.requireNonNull(startupFailurePolicy,
+				"startupFailurePolicy must not be null");
 	}
 
 	public void updateContainerProperties() {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/reader/PulsarReaderContainerProperties.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/reader/PulsarReaderContainerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.pulsar.reader;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Reader;
@@ -25,8 +26,11 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaType;
 
 import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.lang.Nullable;
+import org.springframework.pulsar.config.StartupFailurePolicy;
 import org.springframework.pulsar.core.DefaultSchemaResolver;
 import org.springframework.pulsar.core.SchemaResolver;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
 
 /**
@@ -53,6 +57,16 @@ public class PulsarReaderContainerProperties {
 	private SchemaType schemaType;
 
 	private SchemaResolver schemaResolver;
+
+	@Nullable
+	private RetryTemplate startupFailureRetryTemplate;
+
+	private final RetryTemplate defaultStartupFailureRetryTemplate = RetryTemplate.builder()
+		.maxAttempts(3)
+		.fixedBackoff(Duration.ofSeconds(10))
+		.build();
+
+	private StartupFailurePolicy startupFailurePolicy = StartupFailurePolicy.STOP;
 
 	public Object getReaderListener() {
 		return this.readerListener;
@@ -82,7 +96,10 @@ public class PulsarReaderContainerProperties {
 	 * Set the timeout to wait for a reader thread to start before logging an error.
 	 * Default 30 seconds.
 	 * @param readerStartTimeout the reader start timeout.
+	 * @deprecated As of version 1.2.0 startup policy is controlled via
+	 * {@link #getStartupFailurePolicy()}
 	 */
+	@Deprecated(since = "1.2.0", forRemoval = true)
 	public void setReaderStartTimeout(Duration readerStartTimeout) {
 		Assert.notNull(readerStartTimeout, "'readerStartTimeout' cannot be null");
 		this.readerStartTimeout = readerStartTimeout;
@@ -126,6 +143,48 @@ public class PulsarReaderContainerProperties {
 
 	public void setSchemaResolver(SchemaResolver schemaResolver) {
 		this.schemaResolver = schemaResolver;
+	}
+
+	@Nullable
+	public RetryTemplate getStartupFailureRetryTemplate() {
+		return this.startupFailureRetryTemplate;
+	}
+
+	/**
+	 * Get the default template to use to retry startup when no custom retry template has
+	 * been specified.
+	 * @return the default retry template that will retry 3 times with a fixed delay of 10
+	 * seconds between each attempt.
+	 * @since 1.2.0
+	 */
+	public RetryTemplate getDefaultStartupFailureRetryTemplate() {
+		return this.defaultStartupFailureRetryTemplate;
+	}
+
+	/**
+	 * Set the template to use to retry startup when an exception occurs during startup.
+	 * @param startupFailureRetryTemplate the retry template to use
+	 * @since 1.2.0
+	 */
+	public void setStartupFailureRetryTemplate(RetryTemplate startupFailureRetryTemplate) {
+		this.startupFailureRetryTemplate = startupFailureRetryTemplate;
+		if (this.startupFailureRetryTemplate != null) {
+			setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+		}
+	}
+
+	public StartupFailurePolicy getStartupFailurePolicy() {
+		return this.startupFailurePolicy;
+	}
+
+	/**
+	 * The action to take on the container when a failure occurs during startup.
+	 * @param startupFailurePolicy action to take when a failure occurs during startup
+	 * @since 1.2.0
+	 */
+	public void setStartupFailurePolicy(StartupFailurePolicy startupFailurePolicy) {
+		this.startupFailurePolicy = Objects.requireNonNull(startupFailurePolicy,
+				"startupFailurePolicy must not be null");
 	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -32,6 +35,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
@@ -46,19 +50,27 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.MultiplierRedeliveryBackoff;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.pulsar.PulsarException;
+import org.springframework.pulsar.config.StartupFailurePolicy;
 import org.springframework.pulsar.core.ConsumerTestUtils;
 import org.springframework.pulsar.core.DefaultPulsarConsumerFactory;
 import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
 import org.springframework.pulsar.core.JSONSchemaUtil;
 import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.event.ConsumerFailedToStartEvent;
 import org.springframework.pulsar.test.model.UserRecord;
 import org.springframework.pulsar.test.model.json.UserRecordObjectMapper;
 import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
 import org.springframework.pulsar.transaction.PulsarAwareTransactionManager;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -152,11 +164,11 @@ class DefaultPulsarMessageListenerContainerTests implements PulsarTestContainerS
 
 		container.pause();
 
-		Awaitility.await().until(container::isPaused);
+		await().until(container::isPaused);
 
 		container.resume();
 
-		Awaitility.await().until(() -> !container.isPaused());
+		await().until(() -> !container.isPaused());
 
 		assertThat(latchOnLockInvocation.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latchOnUnlockInvocation.await(10, TimeUnit.SECONDS)).isTrue();
@@ -419,6 +431,8 @@ class DefaultPulsarMessageListenerContainerTests implements PulsarTestContainerS
 		var consumerFactory = new DefaultPulsarConsumerFactory<String>(mock(PulsarClient.class), List.of());
 		var container = new DefaultPulsarMessageListenerContainer<>(consumerFactory, containerProps);
 		assertThatIllegalStateException().isThrownBy(() -> container.start())
+			.withCauseInstanceOf(IllegalStateException.class)
+			.havingRootCause()
 			.withMessage("Transactional batch listeners do not support AckMode.RECORD");
 	}
 
@@ -460,6 +474,174 @@ class DefaultPulsarMessageListenerContainerTests implements PulsarTestContainerS
 
 		container.stop();
 		pulsarClient.close();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nested
+	class WithStartupFailures {
+
+		@Test
+		void whenPolicyIsStopThenExceptionIsThrown() {
+			DefaultPulsarConsumerFactory<String> consumerFactory = mock(DefaultPulsarConsumerFactory.class);
+			var containerProps = new PulsarContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.STOP);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setMessageListener((PulsarRecordMessageListener<?>) (__, ___) -> {
+			});
+			var container = new DefaultPulsarMessageListenerContainer<>(consumerFactory, containerProps);
+			var eventPublisher = mock(ApplicationEventPublisher.class);
+			container.setApplicationEventPublisher(eventPublisher);
+			// setup factory to throw ex when create consumer
+			var failCause = new PulsarException("please-stop");
+			when(consumerFactory.createConsumer(any(Schema.class), any(), any(), any(), any())).thenThrow(failCause);
+			// start container and expect ex thrown
+			assertThatIllegalStateException().isThrownBy(() -> container.start())
+				.withMessageStartingWith("Error starting listener container")
+				.withCause(failCause);
+			assertThat(container.isRunning()).isFalse();
+			verify(eventPublisher)
+				.publishEvent(assertArg((evt) -> assertThat(evt).isInstanceOf(ConsumerFailedToStartEvent.class)
+					.hasFieldOrPropertyWithValue("container", container)));
+		}
+
+		@Test
+		void whenPolicyIsContinueThenExceptionIsNotThrown() {
+			DefaultPulsarConsumerFactory<String> consumerFactory = mock(DefaultPulsarConsumerFactory.class);
+			var containerProps = new PulsarContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.CONTINUE);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setMessageListener((PulsarRecordMessageListener<?>) (__, ___) -> {
+			});
+			var container = new DefaultPulsarMessageListenerContainer<>(consumerFactory, containerProps);
+			var eventPublisher = mock(ApplicationEventPublisher.class);
+			container.setApplicationEventPublisher(eventPublisher);
+			// setup factory to throw ex when create consumer
+			var failCause = new PulsarException("please-continue");
+			when(consumerFactory.createConsumer(any(Schema.class), any(), any(), any(), any())).thenThrow(failCause);
+			// start container and expect ex not thrown
+			container.start();
+			assertThat(container.isRunning()).isFalse();
+			verify(eventPublisher)
+				.publishEvent(assertArg((evt) -> assertThat(evt).isInstanceOf(ConsumerFailedToStartEvent.class)
+					.hasFieldOrPropertyWithValue("container", container)));
+		}
+
+		@Test
+		void whenPolicyIsRetryAndRetriesAreExhaustedThenContainerDoesNotStart() {
+			DefaultPulsarConsumerFactory<String> consumerFactory = mock(DefaultPulsarConsumerFactory.class);
+			var retryCount = new AtomicInteger(0);
+			var thrown = new ArrayList<Throwable>();
+			var retryListener = new RetryListener() {
+				@Override
+				public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					retryCount.set(context.getRetryCount());
+				}
+
+				@Override
+				public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					thrown.add(throwable);
+				}
+			};
+			var retryTemplate = RetryTemplate.builder()
+				.maxAttempts(2)
+				.fixedBackoff(Duration.ofSeconds(1))
+				.withListener(retryListener)
+				.build();
+			var containerProps = new PulsarContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+			containerProps.setStartupFailureRetryTemplate(retryTemplate);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setMessageListener((PulsarRecordMessageListener<?>) (__, ___) -> {
+			});
+			var container = new DefaultPulsarMessageListenerContainer<>(consumerFactory, containerProps);
+			var eventPublisher = mock(ApplicationEventPublisher.class);
+			container.setApplicationEventPublisher(eventPublisher);
+			// setup factory to throw ex on 3 attempts (initial + 2 retries)
+			var failCause = new PulsarException("please-retry-exhausted");
+			doThrow(failCause).doThrow(failCause)
+				.doThrow(failCause)
+				.when(consumerFactory)
+				.createConsumer(any(Schema.class), any(), any(), any(), any());
+			container.start();
+
+			// start container and expect ex not thrown and 2 retries
+			await().atMost(Duration.ofSeconds(15)).until(() -> retryCount.get() == 2);
+			assertThat(thrown).containsExactly(failCause, failCause);
+			assertThat(container.isRunning()).isFalse();
+			// factory called 3x (initial + 2 retries)
+			verify(consumerFactory, times(3)).createConsumer(any(Schema.class), any(), any(), any(), any());
+			verify(eventPublisher)
+				.publishEvent(assertArg((evt) -> assertThat(evt).isInstanceOf(ConsumerFailedToStartEvent.class)
+					.hasFieldOrPropertyWithValue("container", container)));
+		}
+
+		@Test
+		void whenPolicyIsRetryAndRetryIsSuccessfulThenContainerStarts() throws Exception {
+			var topic = "dpmlct-wsf-retry";
+			var pulsarClient = PulsarClient.builder()
+				.serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl())
+				.build();
+			var consumerFactory = spy(
+					new DefaultPulsarConsumerFactory<String>(pulsarClient, List.of((consumerBuilder) -> {
+						consumerBuilder.topic(topic);
+						consumerBuilder.subscriptionName(topic + "-sub");
+					})));
+			var retryCount = new AtomicInteger(0);
+			var thrown = new ArrayList<Throwable>();
+			var retryListener = new RetryListener() {
+				@Override
+				public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					retryCount.set(context.getRetryCount());
+				}
+
+				@Override
+				public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					thrown.add(throwable);
+				}
+			};
+			var retryTemplate = RetryTemplate.builder()
+				.maxAttempts(3)
+				.fixedBackoff(Duration.ofSeconds(1))
+				.withListener(retryListener)
+				.build();
+			var latch = new CountDownLatch(1);
+			var containerProps = new PulsarContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+			containerProps.setStartupFailureRetryTemplate(retryTemplate);
+			containerProps.setMessageListener((PulsarRecordMessageListener<?>) (consumer, msg) -> latch.countDown());
+			containerProps.setSchema(Schema.STRING);
+			var container = new DefaultPulsarMessageListenerContainer<>(consumerFactory, containerProps);
+			var eventPublisher = mock(ApplicationEventPublisher.class);
+			container.setApplicationEventPublisher(eventPublisher);
+			// setup factory to throw ex on initial call and 1st retry - then succeed on
+			// 2nd retry
+			var failCause = new PulsarException("please-retry");
+			doThrow(failCause).doThrow(failCause)
+				.doCallRealMethod()
+				.when(consumerFactory)
+				.createConsumer(any(Schema.class), any(), any(), any(), any());
+			// start container and expect started after retries
+			container.start();
+			await().atMost(Duration.ofSeconds(10)).until(container::isRunning);
+
+			// factory called 3x (initial call + 2 retries)
+			verify(consumerFactory, times(3)).createConsumer(any(Schema.class), any(), any(), any(), any());
+			// only had to retry once (2nd call in retry template succeeded)
+			assertThat(retryCount).hasValue(1);
+			assertThat(thrown).containsExactly(failCause);
+			// should be able to process messages
+			var producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient, topic);
+			var pulsarTemplate = new PulsarTemplate<>(producerFactory);
+			pulsarTemplate.sendAsync("hello-" + topic);
+			assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+			container.stop();
+			pulsarClient.close();
+		}
+
 	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTxnTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTxnTests.java
@@ -248,6 +248,8 @@ class DefaultPulsarMessageListenerContainerTxnTests {
 		var consumerFactory = new DefaultPulsarConsumerFactory<String>(client, List.of());
 		var container = new DefaultPulsarMessageListenerContainer<>(consumerFactory, containerProps);
 		assertThatIllegalStateException().isThrownBy(() -> container.start())
+			.withCauseInstanceOf(IllegalStateException.class)
+			.havingRootCause()
 			.withMessage("Transactional record listeners can not use batch ack mode");
 	}
 
@@ -402,7 +404,7 @@ class DefaultPulsarMessageListenerContainerTxnTests {
 		var container = new DefaultPulsarMessageListenerContainer<>(consumerFactory, containerProps);
 		container.setPulsarConsumerErrorHandler(mock(PulsarConsumerErrorHandler.class));
 		assertThatIllegalStateException().isThrownBy(() -> container.start())
-			.withMessage("Transactional batch listeners do not support custom error handlers");
+			.withStackTraceContaining("Transactional batch listeners do not support custom error handlers");
 	}
 
 	private Consumer<String> startContainerAndSendInputsThenWaitForLatch(String topicIn,

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTxnTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTxnTests.java
@@ -322,7 +322,7 @@ class PulsarListenerTxnTests extends PulsarTxnTestsBase {
 				context.refresh();
 			})
 				.withCauseInstanceOf(IllegalStateException.class)
-				.havingCause()
+				.havingRootCause()
 				.withMessage("Transactions are enabled but txn manager is not set");
 		}
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/reader/DefaultPulsarMessageReaderContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/reader/DefaultPulsarMessageReaderContainerTests.java
@@ -17,11 +17,23 @@
 package org.springframework.pulsar.reader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -30,14 +42,23 @@ import org.apache.pulsar.client.api.ReaderListener;
 import org.apache.pulsar.client.api.Schema;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
+import org.springframework.pulsar.PulsarException;
+import org.springframework.pulsar.config.StartupFailurePolicy;
 import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
 import org.springframework.pulsar.core.DefaultPulsarReaderFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.event.ReaderFailedToStartEvent;
 import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.retry.support.RetryTemplate;
 
 /**
  * Basic tests for {@link DefaultPulsarMessageReaderContainer}.
@@ -141,8 +162,6 @@ public class DefaultPulsarMessageReaderContainerTests implements PulsarTestConta
 		DefaultPulsarMessageReaderContainer<String> container = null;
 		try {
 			container = new DefaultPulsarMessageReaderContainer<>(readerFactory, containerProps);
-
-			var prodConfig = Map.<String, Object>of("topicName", "dprlct-003");
 			var producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient, "dprlct-003",
 					List.of((pb) -> pb.topic("dprlct-003")));
 			var pulsarTemplate = new PulsarTemplate<>(producerFactory);
@@ -171,6 +190,176 @@ public class DefaultPulsarMessageReaderContainerTests implements PulsarTestConta
 		catch (Exception ex) {
 			logger.warn(ex, "Failed to stop container %s: %s".formatted(container, ex.getMessage()));
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nested
+	class WithStartupFailures {
+
+		@Test
+		void whenPolicyIsStopThenExceptionIsThrown() throws Exception {
+			DefaultPulsarReaderFactory<String> readerFactory = mock(DefaultPulsarReaderFactory.class);
+			var containerProps = new PulsarReaderContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.STOP);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setReaderListener((ReaderListener<?>) (__, ___) -> {
+			});
+			var container = new DefaultPulsarMessageReaderContainer<>(readerFactory, containerProps);
+			var eventPublisher = mock(ApplicationEventPublisher.class);
+			container.setApplicationEventPublisher(eventPublisher);
+			// setup factory to throw ex when create reader
+			var failCause = new PulsarException("please-stop");
+			when(readerFactory.createReader(any(), any(), any(), any())).thenThrow(failCause);
+			// start container and expect ex thrown
+			assertThatIllegalStateException().isThrownBy(() -> container.start())
+				.withMessageStartingWith("Error starting reader container")
+				.withCause(failCause);
+			assertThat(container.isRunning()).isFalse();
+			verify(eventPublisher)
+				.publishEvent(assertArg((evt) -> assertThat(evt).isInstanceOf(ReaderFailedToStartEvent.class)
+					.hasFieldOrPropertyWithValue("container", container)));
+		}
+
+		@Test
+		void whenPolicyIsContinueThenExceptionIsNotThrown() throws Exception {
+			DefaultPulsarReaderFactory<String> readerFactory = mock(DefaultPulsarReaderFactory.class);
+			var containerProps = new PulsarReaderContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.CONTINUE);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setReaderListener((ReaderListener<?>) (__, ___) -> {
+			});
+			var container = new DefaultPulsarMessageReaderContainer<>(readerFactory, containerProps);
+			var eventPublisher = mock(ApplicationEventPublisher.class);
+			container.setApplicationEventPublisher(eventPublisher);
+			// setup factory to throw ex when create reader
+			var failCause = new PulsarException("please-continue");
+			when(readerFactory.createReader(any(), any(), any(), any())).thenThrow(failCause);
+			// start container and expect ex not thrown
+			container.start();
+			assertThat(container.isRunning()).isFalse();
+			verify(eventPublisher)
+				.publishEvent(assertArg((evt) -> assertThat(evt).isInstanceOf(ReaderFailedToStartEvent.class)
+					.hasFieldOrPropertyWithValue("container", container)));
+		}
+
+		@Test
+		void whenPolicyIsRetryAndRetriesAreExhaustedThenContainerDoesNotStart() throws Exception {
+			DefaultPulsarReaderFactory<String> readerFactory = mock(DefaultPulsarReaderFactory.class);
+			var retryCount = new AtomicInteger(0);
+			var thrown = new ArrayList<Throwable>();
+			var retryListener = new RetryListener() {
+				@Override
+				public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					retryCount.set(context.getRetryCount());
+				}
+
+				@Override
+				public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					thrown.add(throwable);
+				}
+			};
+			var retryTemplate = RetryTemplate.builder()
+				.maxAttempts(2)
+				.fixedBackoff(Duration.ofSeconds(1))
+				.withListener(retryListener)
+				.build();
+			var containerProps = new PulsarReaderContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+			containerProps.setStartupFailureRetryTemplate(retryTemplate);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setReaderListener((ReaderListener<?>) (__, ___) -> {
+			});
+			var container = new DefaultPulsarMessageReaderContainer<>(readerFactory, containerProps);
+			var eventPublisher = mock(ApplicationEventPublisher.class);
+			container.setApplicationEventPublisher(eventPublisher);
+			// setup factory to throw ex on 3 attempts (initial + 2 retries)
+			var failCause = new PulsarException("please-retry-exhausted");
+			doThrow(failCause).doThrow(failCause)
+				.doThrow(failCause)
+				.when(readerFactory)
+				.createReader(any(), any(), any(), any());
+			container.start();
+
+			// start container and expect ex not thrown and 2 retries
+			await().atMost(Duration.ofSeconds(15)).until(() -> retryCount.get() == 2);
+			assertThat(thrown).containsExactly(failCause, failCause);
+			assertThat(container.isRunning()).isFalse();
+			// factory called 3x (initial + 2 retries)
+			verify(readerFactory, times(3)).createReader(any(), any(), any(), any());
+			verify(eventPublisher)
+				.publishEvent(assertArg((evt) -> assertThat(evt).isInstanceOf(ReaderFailedToStartEvent.class)
+					.hasFieldOrPropertyWithValue("container", container)));
+		}
+
+		@Test
+		void whenPolicyIsRetryAndRetryIsSuccessfulThenContainerStarts() throws Exception {
+			var topic = "dpmlct-wsf-retry";
+			var readerFactory = spy(new DefaultPulsarReaderFactory<String>(pulsarClient, List.of((readerBuilder) -> {
+				readerBuilder.topic(topic);
+				readerBuilder.subscriptionName(topic + "-sub");
+				readerBuilder.startMessageId(MessageId.earliest);
+			})));
+			var retryCount = new AtomicInteger(0);
+			var thrown = new ArrayList<Throwable>();
+			var retryListener = new RetryListener() {
+				@Override
+				public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					retryCount.set(context.getRetryCount());
+				}
+
+				@Override
+				public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					thrown.add(throwable);
+				}
+			};
+			var retryTemplate = RetryTemplate.builder()
+				.maxAttempts(3)
+				.fixedBackoff(Duration.ofSeconds(1))
+				.withListener(retryListener)
+				.build();
+			var latch = new CountDownLatch(1);
+			var containerProps = new PulsarReaderContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+			containerProps.setStartupFailureRetryTemplate(retryTemplate);
+			containerProps.setReaderListener((ReaderListener<?>) (reader, msg) -> latch.countDown());
+			containerProps.setSchema(Schema.STRING);
+			DefaultPulsarMessageReaderContainer<String> container = null;
+			try {
+				container = new DefaultPulsarMessageReaderContainer<>(readerFactory, containerProps);
+				var eventPublisher = mock(ApplicationEventPublisher.class);
+				container.setApplicationEventPublisher(eventPublisher);
+				// setup factory to throw ex on initial call and 1st retry - then succeed
+				// on
+				// 2nd retry
+				var failCause = new PulsarException("please-retry");
+				doThrow(failCause).doThrow(failCause)
+					.doCallRealMethod()
+					.when(readerFactory)
+					.createReader(any(), any(), any(), any());
+				// start container and expect started after retries
+				container.start();
+				await().atMost(Duration.ofSeconds(10)).until(container::isRunning);
+
+				// factory called 3x (initial call + 2 retries)
+				verify(readerFactory, times(3)).createReader(any(), any(), any(), any());
+				// only had to retry once (2nd call in retry template succeeded)
+				assertThat(retryCount).hasValue(1);
+				assertThat(thrown).containsExactly(failCause);
+				// should be able to process messages
+				var producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient, topic);
+				var pulsarTemplate = new PulsarTemplate<>(producerFactory);
+				pulsarTemplate.sendAsync("hello-" + topic);
+				assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+			}
+			finally {
+				safeStopContainer(container);
+			}
+		}
+
 	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/reader/DefaultPulsarMessageReaderContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/reader/DefaultPulsarMessageReaderContainerTests.java
@@ -172,7 +172,7 @@ public class DefaultPulsarMessageReaderContainerTests implements PulsarTestConta
 				pulsarTemplate.send("This message should not be received by the reader");
 			}
 			container.start();
-			assertThat(container.isRunning()).isTrue();
+			await().atMost(Duration.ofSeconds(10)).until(container::isRunning);
 			pulsarTemplate.sendAsync("This message should be received by the reader");
 			pulsarTemplate.sendAsync("This message should be received by the reader");
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/reader/DefaultPulsarMessageReaderContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/reader/DefaultPulsarMessageReaderContainerTests.java
@@ -318,7 +318,7 @@ public class DefaultPulsarMessageReaderContainerTests implements PulsarTestConta
 			};
 			var retryTemplate = RetryTemplate.builder()
 				.maxAttempts(3)
-				.fixedBackoff(Duration.ofSeconds(1))
+				.fixedBackoff(Duration.ofSeconds(2))
 				.withListener(retryListener)
 				.build();
 			var latch = new CountDownLatch(1);
@@ -342,7 +342,7 @@ public class DefaultPulsarMessageReaderContainerTests implements PulsarTestConta
 					.createReader(any(), any(), any(), any());
 				// start container and expect started after retries
 				container.start();
-				await().atMost(Duration.ofSeconds(10)).until(container::isRunning);
+				await().atMost(Duration.ofSeconds(20)).until(container::isRunning);
 
 				// factory called 3x (initial call + 2 retries)
 				verify(readerFactory, times(3)).createReader(any(), any(), any(), any());


### PR DESCRIPTION
Previously, when a listener container failed to start, it would only log the exception. This commit introduces `StartupFailurePolicy` that allows listener containers to CONTINUE, STOP, RETRY when an error is encountered on startup.

See #445
See #816

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
