### PR TITLE
Add startup failure policy to listener

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/message-listener-startup-failure.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/message-listener-startup-failure.adoc
@@ -1,0 +1,28 @@
+= Handling Startup Failures
+include::../attributes/attributes-variables.adoc[]
+
+Message listener containers are started when the application context is refreshed.
+By default, any failures encountered during startup are re-thrown and the application will fail to start.
+You can adjust this behavior with the `StartupFailurePolicy` on the corresponding container properties.
+
+The available options are:
+
+- `Stop` (default) - log and re-throw the exception, effectively stopping the application
+- `Continue` - log the exception, leave the container in a non-running state, but do not stop the application
+- `Retry` - log the exception, retry to start the container asynchronously, but do not stop the application.
+
+The default retry behavior is to retry 3 times with a 10-second delay between
+each attempt.
+However, a custom retry template can be specified on the corresponding container properties.
+If the container fails to restart after the retries are exhausted, it is left in a non-running state.
+
+[discrete]
+== Configuration
+
+[discrete]
+=== With Spring Boot
+**TODO**
+
+[discrete]
+=== Without Spring Boot
+**TODO**

--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar/message-consumption.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar/message-consumption.adoc
@@ -951,8 +951,11 @@ The framework detects the provided bean through the `PulsarListener` and applies
 
 If you have multiple `PulsarListener` methods, and each of them have different customization rules, you should create multiple customizer beans and attach the proper customizers on each `PulsarListener`.
 
+[[message-listener-lifecycle]]
+== Message Listener Container Lifecycle
 
-== Pausing and Resuming Message Listener Containers
+[[message-listener-pause-resume]]
+=== Pausing and Resuming
 
 There are situations in which an application might want to pause message consumption temporarily and then resume later.
 Spring for Apache Pulsar provides the ability to pause and resume the underlying message listener containers.
@@ -972,6 +975,10 @@ void someMethod() {
 ----
 
 TIP: The id parameter passed to `getListenerContainer` is the container id - which will be the value of the `@PulsarListener` id attribute when pausing/resuming a `@PulsarListener`.
+
+[[message-listener-startup-failure]]
+include::../message-listener-startup-failure.adoc[leveloffset=+2]
+
 
 [[imperative-pulsar-reader]]
 == Pulsar Reader Support
@@ -1023,3 +1030,6 @@ public PulsarReaderReaderBuilderCustomizer<String> myCustomizer() {
 ----
 
 TIP: If your application only has a single `@PulsarReader` and a single `PulsarReaderReaderBuilderCustomizer` bean registered then the customizer will be automatically applied.
+
+=== Handling Startup Failures
+The same xref:#message-listener-startup-failure[startup failure facilities] available to message listener containers are available for reader containers.

--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/reactive-pulsar/reactive-message-consumption.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/reactive-pulsar/reactive-message-consumption.adoc
@@ -206,6 +206,9 @@ The "listener" aspect is provided by the `ReactivePulsarMessageHandler` of which
 
 NOTE: If topic information is not specified when using the listener containers directly, the same xref:reference/topic-resolution.adoc#topic-resolution-process[topic resolution process] used by the `ReactivePulsarListener` is used with the one exception that the "Message type default" step is **omitted**.
 
+[[message-listener-startup-failure]]
+include::../message-listener-startup-failure.adoc[leveloffset=+2]
+
 [[reactive-concurrency]]
 == Concurrency
 When consuming records in streaming mode (`stream = true`) concurrency comes naturally via the underlying Reactive support in the client implementation.

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/ReactivePulsarContainerProperties.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/ReactivePulsarContainerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,16 +18,20 @@ package org.springframework.pulsar.reactive.listener;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.schema.SchemaType;
 
+import org.springframework.lang.Nullable;
+import org.springframework.pulsar.config.StartupFailurePolicy;
 import org.springframework.pulsar.core.DefaultSchemaResolver;
 import org.springframework.pulsar.core.DefaultTopicResolver;
 import org.springframework.pulsar.core.SchemaResolver;
 import org.springframework.pulsar.core.TopicResolver;
+import org.springframework.retry.support.RetryTemplate;
 
 /**
  * Contains runtime properties for a reactive listener container.
@@ -60,6 +64,16 @@ public class ReactivePulsarContainerProperties<T> {
 	private int concurrency = 0;
 
 	private boolean useKeyOrderedProcessing = false;
+
+	@Nullable
+	private RetryTemplate startupFailureRetryTemplate;
+
+	private final RetryTemplate defaultStartupFailureRetryTemplate = RetryTemplate.builder()
+		.maxAttempts(3)
+		.fixedBackoff(Duration.ofSeconds(10))
+		.build();
+
+	private StartupFailurePolicy startupFailurePolicy = StartupFailurePolicy.STOP;
 
 	public ReactivePulsarMessageHandler getMessageHandler() {
 		return this.messageHandler;
@@ -159,6 +173,48 @@ public class ReactivePulsarContainerProperties<T> {
 
 	public void setUseKeyOrderedProcessing(boolean useKeyOrderedProcessing) {
 		this.useKeyOrderedProcessing = useKeyOrderedProcessing;
+	}
+
+	@Nullable
+	public RetryTemplate getStartupFailureRetryTemplate() {
+		return this.startupFailureRetryTemplate;
+	}
+
+	/**
+	 * Get the default template to use to retry startup when no custom retry template has
+	 * been specified.
+	 * @return the default retry template that will retry 3 times with a fixed delay of 10
+	 * seconds between each attempt.
+	 * @since 1.2.0
+	 */
+	public RetryTemplate getDefaultStartupFailureRetryTemplate() {
+		return this.defaultStartupFailureRetryTemplate;
+	}
+
+	/**
+	 * Set the template to use to retry startup when an exception occurs during startup.
+	 * @param startupFailureRetryTemplate the retry template to use
+	 * @since 1.2.0
+	 */
+	public void setStartupFailureRetryTemplate(RetryTemplate startupFailureRetryTemplate) {
+		this.startupFailureRetryTemplate = startupFailureRetryTemplate;
+		if (this.startupFailureRetryTemplate != null) {
+			setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+		}
+	}
+
+	public StartupFailurePolicy getStartupFailurePolicy() {
+		return this.startupFailurePolicy;
+	}
+
+	/**
+	 * The action to take on the container when a failure occurs during startup.
+	 * @param startupFailurePolicy action to take when a failure occurs during startup
+	 * @since 1.2.0
+	 */
+	public void setStartupFailurePolicy(StartupFailurePolicy startupFailurePolicy) {
+		this.startupFailurePolicy = Objects.requireNonNull(startupFailurePolicy,
+				"startupFailurePolicy must not be null");
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/StartupFailurePolicy.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/StartupFailurePolicy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.config;
+
+/**
+ * The action to take on the container when a failure occurs during startup.
+ *
+ * @author Chris Bono
+ * @since 1.2.0
+ */
+public enum StartupFailurePolicy {
+
+	/** Stop the container and throw exception. */
+	STOP,
+
+	/** Stop the container but do not throw exception. */
+	CONTINUE,
+
+	/** Retry startup. */
+	RETRY
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
@@ -137,9 +137,7 @@ public class ConcurrentPulsarMessageListenerContainer<T> extends AbstractPulsarM
 	public void doStop() {
 		if (isRunning()) {
 			setRunning(false);
-			for (DefaultPulsarMessageListenerContainer<T> pulsarMessageListenerContainer : this.containers) {
-				pulsarMessageListenerContainer.stop();
-			}
+			this.containers.forEach(DefaultPulsarMessageListenerContainer::stop);
 			this.containers.clear();
 		}
 	}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerStartupFailureTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerStartupFailureTests.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.pulsar.config.StartupFailurePolicy;
+import org.springframework.pulsar.core.DefaultPulsarConsumerFactory;
+import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
+import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * Tests the startup failures policy on the
+ * {@link ConcurrentPulsarMessageListenerContainer}.
+ */
+@SuppressWarnings("unchecked")
+class ConcurrentPulsarMessageListenerContainerStartupFailureTests implements PulsarTestContainerSupport {
+
+	private final LogAccessor logger = new LogAccessor(this.getClass());
+
+	@Test
+	void whenPolicyIsStopThenExceptionIsThrown() throws Exception {
+		var topic = "cpmlcsft-stop";
+		var pulsarClient = PulsarClient.builder().serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl()).build();
+		ConcurrentPulsarMessageListenerContainer<String> container = null;
+		try {
+			var consumerFactory = spy(
+					new DefaultPulsarConsumerFactory<String>(pulsarClient, List.of((consumerBuilder) -> {
+						consumerBuilder.topic(topic);
+						consumerBuilder.subscriptionName(topic + "-sub");
+						consumerBuilder.subscriptionType(SubscriptionType.Shared);
+					})));
+			var containerProps = new PulsarContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.STOP);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setConcurrency(3);
+			containerProps.setMessageListener((PulsarRecordMessageListener<?>) (__, ___) -> {
+			});
+			container = new ConcurrentPulsarMessageListenerContainer<>(consumerFactory, containerProps);
+			container.setConcurrency(containerProps.getConcurrency());
+
+			// setup factory (c1 pass, c2 fail, c3 pass)
+			var failCause = new IllegalStateException("please-stop");
+			doCallRealMethod().doThrow(failCause)
+				.doCallRealMethod()
+				.when(consumerFactory)
+				.createConsumer(any(Schema.class), any(), any(), any(), any());
+
+			var parentContainer = container;
+			assertThatIllegalStateException().isThrownBy(() -> parentContainer.start())
+				.withMessageStartingWith("Error starting listener container [consumer-1]")
+				.withCause(failCause);
+		}
+		finally {
+			safeStopContainer(container);
+			pulsarClient.close();
+		}
+	}
+
+	@Test
+	void whenPolicyIsContinueThenExceptionIsNotThrown() throws Exception {
+		var topic = "cpmlcsft-continue";
+		var pulsarClient = PulsarClient.builder().serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl()).build();
+		ConcurrentPulsarMessageListenerContainer<String> container = null;
+		try {
+			var consumerFactory = spy(
+					new DefaultPulsarConsumerFactory<String>(pulsarClient, List.of((consumerBuilder) -> {
+						consumerBuilder.topic(topic);
+						consumerBuilder.subscriptionName(topic + "-sub");
+						consumerBuilder.subscriptionType(SubscriptionType.Shared);
+					})));
+			var containerProps = new PulsarContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.CONTINUE);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setConcurrency(3);
+			var latch = new CountDownLatch(1);
+			containerProps.setMessageListener((PulsarRecordMessageListener<?>) (consumer, msg) -> latch.countDown());
+			container = new ConcurrentPulsarMessageListenerContainer<>(consumerFactory, containerProps);
+			container.setConcurrency(containerProps.getConcurrency());
+
+			// setup factory (c1 pass, c2 fail, c3 pass)
+			var failCause = new IllegalStateException("please-continue");
+			doCallRealMethod().doThrow(failCause)
+				.doCallRealMethod()
+				.when(consumerFactory)
+				.createConsumer(any(Schema.class), any(), any(), any(), any());
+
+			// start container and expect started after retries
+			container.start();
+			assertThat(container.getContainers()).hasSize(3)
+				.extracting(DefaultPulsarMessageListenerContainer::isRunning)
+				.containsExactly(true, false, true);
+			assertThat(container.isRunning()).isTrue();
+
+			// should be able to process messages
+			var producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient, topic);
+			var pulsarTemplate = new PulsarTemplate<>(producerFactory);
+			pulsarTemplate.sendAsync("hello-" + topic);
+			assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+		finally {
+			safeStopContainer(container);
+			pulsarClient.close();
+		}
+	}
+
+	@Test
+	void whenPolicyIsRetryAndRetryIsSuccessfulThenContainerStarts() throws Exception {
+		var topic = "cpmlcsft-retry";
+		var pulsarClient = PulsarClient.builder().serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl()).build();
+		ConcurrentPulsarMessageListenerContainer<String> container = null;
+		try {
+			var consumerFactory = spy(
+					new DefaultPulsarConsumerFactory<String>(pulsarClient, List.of((consumerBuilder) -> {
+						consumerBuilder.topic(topic);
+						consumerBuilder.subscriptionName(topic + "-sub");
+						consumerBuilder.subscriptionType(SubscriptionType.Shared);
+					})));
+			var containerProps = new PulsarContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setConcurrency(3);
+			var retryTemplate = RetryTemplate.builder().maxAttempts(2).fixedBackoff(Duration.ofSeconds(2)).build();
+			containerProps.setStartupFailureRetryTemplate(retryTemplate);
+			var latch = new CountDownLatch(1);
+			containerProps.setMessageListener((PulsarRecordMessageListener<?>) (consumer, msg) -> latch.countDown());
+			container = new ConcurrentPulsarMessageListenerContainer<>(consumerFactory, containerProps);
+			container.setConcurrency(containerProps.getConcurrency());
+
+			// setup factory (c1 fail, c2 fail/retry, c3 fail)
+			var failCause = new IllegalStateException("please-retry");
+			doThrow(failCause).doThrow(failCause)
+				.doThrow(failCause)
+				.doCallRealMethod()
+				.doCallRealMethod()
+				.doCallRealMethod()
+				.when(consumerFactory)
+				.createConsumer(any(Schema.class), any(), any(), any(), any());
+
+			// start container and expect started after retries
+			container.start();
+			var parentContainer = container;
+			await().atMost(Duration.ofSeconds(10))
+				.untilAsserted(() -> assertThat(parentContainer.getContainers()).hasSize(3)
+					.extracting(DefaultPulsarMessageListenerContainer::isRunning)
+					.containsExactly(true, true, true));
+			assertThat(container.isRunning()).isTrue();
+
+			// should be able to process messages
+			var producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient, topic);
+			var pulsarTemplate = new PulsarTemplate<>(producerFactory);
+			pulsarTemplate.sendAsync("hello-" + topic);
+			assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+		finally {
+			safeStopContainer(container);
+			pulsarClient.close();
+		}
+	}
+
+	private void safeStopContainer(PulsarMessageListenerContainer container) {
+		try {
+			container.stop();
+		}
+		catch (Exception ex) {
+			logger.warn(ex, "Failed to stop container %s: %s".formatted(container, ex.getMessage()));
+		}
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTxnTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTxnTests.java
@@ -248,6 +248,7 @@ class DefaultPulsarMessageListenerContainerTxnTests {
 		var consumerFactory = new DefaultPulsarConsumerFactory<String>(client, List.of());
 		var container = new DefaultPulsarMessageListenerContainer<>(consumerFactory, containerProps);
 		assertThatIllegalStateException().isThrownBy(() -> container.start())
+			.havingRootCause()
 			.withMessage("Transactional record listeners can not use batch ack mode");
 	}
 
@@ -402,6 +403,7 @@ class DefaultPulsarMessageListenerContainerTxnTests {
 		var container = new DefaultPulsarMessageListenerContainer<>(consumerFactory, containerProps);
 		container.setPulsarConsumerErrorHandler(mock(PulsarConsumerErrorHandler.class));
 		assertThatIllegalStateException().isThrownBy(() -> container.start())
+			.havingRootCause()
 			.withMessage("Transactional batch listeners do not support custom error handlers");
 	}
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTxnTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTxnTests.java
@@ -322,7 +322,7 @@ class PulsarListenerTxnTests extends PulsarTxnTestsBase {
 				context.refresh();
 			})
 				.withCauseInstanceOf(IllegalStateException.class)
-				.havingCause()
+				.havingRootCause()
 				.withMessage("Transactions are enabled but txn manager is not set");
 		}
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/reader/DefaultPulsarMessageReaderContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/reader/DefaultPulsarMessageReaderContainerTests.java
@@ -17,11 +17,23 @@
 package org.springframework.pulsar.reader;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -30,14 +42,23 @@ import org.apache.pulsar.client.api.ReaderListener;
 import org.apache.pulsar.client.api.Schema;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
+import org.springframework.pulsar.PulsarException;
+import org.springframework.pulsar.config.StartupFailurePolicy;
 import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
 import org.springframework.pulsar.core.DefaultPulsarReaderFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.event.ReaderFailedToStartEvent;
 import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.retry.support.RetryTemplate;
 
 /**
  * Basic tests for {@link DefaultPulsarMessageReaderContainer}.
@@ -110,9 +131,8 @@ public class DefaultPulsarMessageReaderContainerTests implements PulsarTestConta
 		containerProps.setStartMessageId(MessageId.earliest);
 		containerProps.setTopics(List.of("dprlct-002"));
 		containerProps.setSchema(Schema.STRING);
-		DefaultPulsarMessageReaderContainer<String> container = null;
+		var container = new DefaultPulsarMessageReaderContainer<>(pulsarReaderFactory, containerProps);
 		try {
-			container = new DefaultPulsarMessageReaderContainer<>(pulsarReaderFactory, containerProps);
 			container.start();
 			DefaultPulsarProducerFactory<String> pulsarProducerFactory = new DefaultPulsarProducerFactory<>(
 					pulsarClient, "dprlct-002", List.of((pb) -> pb.topic("dprlct-002")));
@@ -141,8 +161,6 @@ public class DefaultPulsarMessageReaderContainerTests implements PulsarTestConta
 		DefaultPulsarMessageReaderContainer<String> container = null;
 		try {
 			container = new DefaultPulsarMessageReaderContainer<>(readerFactory, containerProps);
-
-			var prodConfig = Map.<String, Object>of("topicName", "dprlct-003");
 			var producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient, "dprlct-003",
 					List.of((pb) -> pb.topic("dprlct-003")));
 			var pulsarTemplate = new PulsarTemplate<>(producerFactory);
@@ -153,7 +171,7 @@ public class DefaultPulsarMessageReaderContainerTests implements PulsarTestConta
 				pulsarTemplate.send("This message should not be received by the reader");
 			}
 			container.start();
-			assertThat(container.isRunning()).isTrue();
+			await().atMost(Duration.ofSeconds(10)).until(container::isRunning);
 			pulsarTemplate.sendAsync("This message should be received by the reader");
 			pulsarTemplate.sendAsync("This message should be received by the reader");
 
@@ -171,6 +189,174 @@ public class DefaultPulsarMessageReaderContainerTests implements PulsarTestConta
 		catch (Exception ex) {
 			logger.warn(ex, "Failed to stop container %s: %s".formatted(container, ex.getMessage()));
 		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nested
+	class WithStartupFailures {
+
+		@Test
+		void whenPolicyIsStopThenExceptionIsThrown() throws Exception {
+			DefaultPulsarReaderFactory<String> readerFactory = mock(DefaultPulsarReaderFactory.class);
+			var containerProps = new PulsarReaderContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.STOP);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setReaderListener((ReaderListener<?>) (__, ___) -> {
+			});
+			var container = new DefaultPulsarMessageReaderContainer<>(readerFactory, containerProps);
+			var eventPublisher = mock(ApplicationEventPublisher.class);
+			container.setApplicationEventPublisher(eventPublisher);
+			// setup factory to throw ex when create reader
+			var failCause = new PulsarException("please-stop");
+			when(readerFactory.createReader(any(), any(), any(), any())).thenThrow(failCause);
+			// start container and expect ex thrown
+			assertThatIllegalStateException().isThrownBy(() -> container.start())
+				.withMessageStartingWith("Error starting reader container")
+				.withCause(failCause);
+			assertThat(container.isRunning()).isFalse();
+			verify(eventPublisher)
+				.publishEvent(assertArg((evt) -> assertThat(evt).isInstanceOf(ReaderFailedToStartEvent.class)
+					.hasFieldOrPropertyWithValue("container", container)));
+		}
+
+		@Test
+		void whenPolicyIsContinueThenExceptionIsNotThrown() throws Exception {
+			DefaultPulsarReaderFactory<String> readerFactory = mock(DefaultPulsarReaderFactory.class);
+			var containerProps = new PulsarReaderContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.CONTINUE);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setReaderListener((ReaderListener<?>) (__, ___) -> {
+			});
+			var container = new DefaultPulsarMessageReaderContainer<>(readerFactory, containerProps);
+			var eventPublisher = mock(ApplicationEventPublisher.class);
+			container.setApplicationEventPublisher(eventPublisher);
+			// setup factory to throw ex when create reader
+			var failCause = new PulsarException("please-continue");
+			when(readerFactory.createReader(any(), any(), any(), any())).thenThrow(failCause);
+			// start container and expect ex not thrown
+			container.start();
+			assertThat(container.isRunning()).isFalse();
+			verify(eventPublisher)
+				.publishEvent(assertArg((evt) -> assertThat(evt).isInstanceOf(ReaderFailedToStartEvent.class)
+					.hasFieldOrPropertyWithValue("container", container)));
+		}
+
+		@Test
+		void whenPolicyIsRetryAndRetriesAreExhaustedThenContainerDoesNotStart() throws Exception {
+			DefaultPulsarReaderFactory<String> readerFactory = mock(DefaultPulsarReaderFactory.class);
+			var retryCount = new AtomicInteger(0);
+			var thrown = new ArrayList<Throwable>();
+			var retryListener = new RetryListener() {
+				@Override
+				public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					retryCount.set(context.getRetryCount());
+				}
+
+				@Override
+				public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					thrown.add(throwable);
+				}
+			};
+			var retryTemplate = RetryTemplate.builder()
+				.maxAttempts(2)
+				.fixedBackoff(Duration.ofSeconds(2))
+				.withListener(retryListener)
+				.build();
+			var containerProps = new PulsarReaderContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+			containerProps.setStartupFailureRetryTemplate(retryTemplate);
+			containerProps.setSchema(Schema.STRING);
+			containerProps.setReaderListener((ReaderListener<?>) (__, ___) -> {
+			});
+			var container = new DefaultPulsarMessageReaderContainer<>(readerFactory, containerProps);
+			var eventPublisher = mock(ApplicationEventPublisher.class);
+			container.setApplicationEventPublisher(eventPublisher);
+			// setup factory to throw ex on 3 attempts (initial + 2 retries)
+			var failCause = new PulsarException("please-retry-exhausted");
+			doThrow(failCause).doThrow(failCause)
+				.doThrow(failCause)
+				.when(readerFactory)
+				.createReader(any(), any(), any(), any());
+			container.start();
+
+			// start container and expect ex not thrown and 2 retries
+			await().atMost(Duration.ofSeconds(15)).until(() -> retryCount.get() == 2);
+			assertThat(thrown).containsExactly(failCause, failCause);
+			assertThat(container.isRunning()).isFalse();
+			// factory called 3x (initial + 2 retries)
+			verify(readerFactory, times(3)).createReader(any(), any(), any(), any());
+			verify(eventPublisher)
+				.publishEvent(assertArg((evt) -> assertThat(evt).isInstanceOf(ReaderFailedToStartEvent.class)
+					.hasFieldOrPropertyWithValue("container", container)));
+		}
+
+		@Test
+		void whenPolicyIsRetryAndRetryIsSuccessfulThenContainerStarts() throws Exception {
+			var topic = "dprlct-wsf-retry";
+			var readerFactory = spy(new DefaultPulsarReaderFactory<String>(pulsarClient, List.of((readerBuilder) -> {
+				readerBuilder.topic(topic);
+				readerBuilder.subscriptionName(topic + "-sub");
+				readerBuilder.startMessageId(MessageId.earliest);
+			})));
+			var retryCount = new AtomicInteger(0);
+			var thrown = new ArrayList<Throwable>();
+			var retryListener = new RetryListener() {
+				@Override
+				public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					retryCount.set(context.getRetryCount());
+				}
+
+				@Override
+				public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+						Throwable throwable) {
+					thrown.add(throwable);
+				}
+			};
+			var retryTemplate = RetryTemplate.builder()
+				.maxAttempts(3)
+				.fixedBackoff(Duration.ofSeconds(2))
+				.withListener(retryListener)
+				.build();
+			var latch = new CountDownLatch(1);
+			var containerProps = new PulsarReaderContainerProperties();
+			containerProps.setStartupFailurePolicy(StartupFailurePolicy.RETRY);
+			containerProps.setStartupFailureRetryTemplate(retryTemplate);
+			containerProps.setReaderListener((ReaderListener<?>) (reader, msg) -> latch.countDown());
+			containerProps.setSchema(Schema.STRING);
+			var container = new DefaultPulsarMessageReaderContainer<>(readerFactory, containerProps);
+			try {
+				var eventPublisher = mock(ApplicationEventPublisher.class);
+				container.setApplicationEventPublisher(eventPublisher);
+				// setup factory to throw ex on initial call and 1st retry - then succeed
+				// on 2nd retry
+				var failCause = new PulsarException("please-retry");
+				doThrow(failCause).doThrow(failCause)
+					.doCallRealMethod()
+					.when(readerFactory)
+					.createReader(any(), any(), any(), any());
+				// start container and expect started after retries
+				container.start();
+				await().atMost(Duration.ofSeconds(20)).until(container::isRunning);
+
+				// factory called 3x (initial call + 2 retries)
+				verify(readerFactory, times(3)).createReader(any(), any(), any(), any());
+				// only had to retry once (2nd call in retry template succeeded)
+				assertThat(retryCount).hasValue(1);
+				assertThat(thrown).containsExactly(failCause);
+				// should be able to process messages
+				var producerFactory = new DefaultPulsarProducerFactory<>(pulsarClient, topic);
+				var pulsarTemplate = new PulsarTemplate<>(producerFactory);
+				pulsarTemplate.sendAsync("hello-" + topic);
+				assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+			}
+			finally {
+				safeStopContainer(container);
+			}
+		}
+
 	}
 
 }


### PR DESCRIPTION
Previously, when a listener container failed to start, it would only log the exception. This commit introduces `StartupFailurePolicy` that allows listener containers to CONTINUE, STOP, RETRY when an error is encountered on startup.

See #445
See #816

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
