### PR TITLE
Add concurrency to PulsarContainerProperties

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author Chris Bono
  * @author Alexander Preuß
+ * @author Vedran Pavic
  */
 public class ConcurrentPulsarListenerContainerFactory<T>
 		extends AbstractPulsarListenerContainerFactory<ConcurrentPulsarMessageListenerContainer<T>, T> {
@@ -43,8 +44,6 @@ public class ConcurrentPulsarListenerContainerFactory<T>
 	private static final String SUBSCRIPTION_NAME_PREFIX = "org.springframework.Pulsar.PulsarListenerEndpointContainer#";
 
 	private static final AtomicInteger COUNTER = new AtomicInteger();
-
-	private Integer concurrency;
 
 	public ConcurrentPulsarListenerContainerFactory(PulsarConsumerFactory<? super T> consumerFactory,
 			PulsarContainerProperties containerProperties) {
@@ -55,8 +54,9 @@ public class ConcurrentPulsarListenerContainerFactory<T>
 	 * Specify the container concurrency.
 	 * @param concurrency the number of consumers to create.
 	 */
+	@Deprecated(since = "1.2.0", forRemoval = true)
 	public void setConcurrency(Integer concurrency) {
-		this.concurrency = concurrency;
+		getContainerProperties().setConcurrency(concurrency);
 	}
 
 	@Override
@@ -71,7 +71,6 @@ public class ConcurrentPulsarListenerContainerFactory<T>
 		};
 		ConcurrentPulsarMessageListenerContainer<T> container = createContainerInstance(endpoint);
 		initializeContainer(container, endpoint);
-		// customizeContainer(container);
 		return container;
 	}
 
@@ -130,8 +129,8 @@ public class ConcurrentPulsarListenerContainerFactory<T>
 		if (endpoint.getConcurrency() != null) {
 			instance.setConcurrency(endpoint.getConcurrency());
 		}
-		else if (this.concurrency != null) {
-			instance.setConcurrency(this.concurrency);
+		else if (getContainerProperties().getConcurrency() > 0) {
+			instance.setConcurrency(getContainerProperties().getConcurrency());
 		}
 	}
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import io.micrometer.observation.ObservationRegistry;
  * @author Soby Chacko
  * @author Alexander Preuß
  * @author Chris Bono
+ * @author Vedran Pavic
  */
 public class PulsarContainerProperties {
 
@@ -76,6 +77,8 @@ public class PulsarContainerProperties {
 	private Object messageListener;
 
 	private AsyncTaskExecutor consumerTaskExecutor;
+
+	private int concurrency = 1;
 
 	private int maxNumMessages = -1;
 
@@ -125,6 +128,14 @@ public class PulsarContainerProperties {
 
 	public void setConsumerTaskExecutor(AsyncTaskExecutor consumerExecutor) {
 		this.consumerTaskExecutor = consumerExecutor;
+	}
+
+	public int getConcurrency() {
+		return this.concurrency;
+	}
+
+	public void setConcurrency(int concurrency) {
+		this.concurrency = concurrency;
 	}
 
 	public SubscriptionType getSubscriptionType() {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,9 +63,9 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 		containerProperties.setBatchTimeoutMillis(60_000);
 		containerProperties.setMaxNumMessages(120);
 		containerProperties.setMaxNumBytes(32000);
+		containerProperties.setConcurrency(1);
 		ConcurrentPulsarListenerContainerFactory<String> containerFactory = new ConcurrentPulsarListenerContainerFactory<>(
 				consumerFactory, containerProperties);
-		containerFactory.setConcurrency(1);
 		PulsarListenerEndpoint pulsarListenerEndpoint = mock(PulsarListenerEndpoint.class);
 		when(pulsarListenerEndpoint.getConcurrency()).thenReturn(1);
 


### PR DESCRIPTION
This commit adds concurrency property to `PulsarContainerProperties` instead of managing it directly on
`ConcurrentPulsarListenerContainerFactory`, which provides consistency with both reactive counterpart and container properties in general.

Resolves: gh-820

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
