### PR TITLE
Deprecate container factory customizer

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar/transactions.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar/transactions.adoc
@@ -138,13 +138,13 @@ These settings affect all listener containers, including the ones used by `@Puls
 
 When not using Spring Boot, you can adjust these settings on the container factory that you provide.
 However, when using Spring Boot, the container factory is auto-configured.
-In this case you can register a `ConcurrentPulsarListenerContainerFactoryCustomizer` bean to access and customize the container properties.
+In this case you can register a `org.springframework.boot.autoconfigure.pulsar.PulsarContainerFactoryCustomizer<ConcurrentPulsarListenerContainerFactory<?>>` bean to access and customize the container properties.
 The following example shows how to set the timeout on the container factory:
 
 [source, java]
 ----
 @Bean
-ConcurrentPulsarListenerContainerFactoryCustomizer<?> containerCustomizer() {
+PulsarContainerFactoryCustomizer<ConcurrentPulsarListenerContainerFactory<?>> containerCustomizer() {
     return (containerFactory) -> containerFactory.getContainerProperties().transactions().setTimeout(Duration.ofSeconds(45));
 }
 ----

--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -18,6 +18,14 @@ See xref:./reference/default-tenant-namespace.adoc[Default Tenant / Namespace] f
 You can now configure the message listener container startup failure policy to `stop`, `continue`, or `retry`.
 For more details see the corresponding section for one of the supported containers xref:./reference/pulsar/message-consumption.adoc#message-listener-startup-failure[@PulsarListener], xref:./reference/pulsar/message-consumption.adoc#message-reader-startup-failure[@PulsarReader], or xref:./reference/reactive-pulsar/reactive-message-consumption.adoc#message-listener-startup-failure[@ReactivePulsarListener]
 
+=== Message Container Factory Customizers (Spring Boot)
+Spring Boot has introduced a generic message container factory customizer `org.springframework.boot.autoconfigure.pulsar.PulsarContainerFactoryCustomizer<T extends PulsarContainerFactory<?, ?>>` that can be used to further configure one or more of the auto-configured container factories that back the following listener annotations:
+
+- For `@PulsarListener` register one or more PulsarContainerFactoryCustomizer<ConcurrentPulsarListenerContainerFactory<?>> beans.
+
+- For `@PulsarReader` register one or more PulsarContainerFactoryCustomizer<DefaultPulsarReaderContainerFactory<?>> beans.
+
+- For `@ReactivePulsarListener` register one or more PulsarContainerFactoryCustomizer<DefaultReactivePulsarListenerContainerFactory<?>> beans.
 
 
 === Deprecations
@@ -39,6 +47,13 @@ As part of this, the following APIs were deprecated, copied, and renamed:
 - `ReaderContainerFactory#createReaderContainer(E endpoint)` replaced with `ReaderContainerFactory#createRegisteredContainer`
 
 - `ReaderContainerFactory#createReaderContainer(String... topics)` replaced with `ReaderContainerFactory#createContainer`
+
+==== ConcurrentPulsarListenerContainerFactoryCustomizer
+The purpose of `ConcurrentPulsarListenerContainerFactoryCustomizer` was to customize the Spring Boot auto-configured message container factories.
+However, Spring Boot has introduced a generic message container factory customizer `org.springframework.boot.autoconfigure.pulsar.PulsarContainerFactoryCustomizer<T extends PulsarContainerFactory<?, ?>>` that removes the need for this customizer.
+
+Replace all instances of `ConcurrentPulsarListenerContainerFactoryCustomizer` with `org.springframework.boot.autoconfigure.pulsar.PulsarContainerFactoryCustomizer<ConcurrentPulsarListenerContainerFactoryCustomizer<?>>`.
+
 
 
 === Breaking Changes

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/ConcurrentPulsarListenerContainerFactoryBeanCustomizerPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/ConcurrentPulsarListenerContainerFactoryBeanCustomizerPostProcessor.java
@@ -34,6 +34,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Chris Bono
  */
+@SuppressWarnings("removal")
 class ConcurrentPulsarListenerContainerFactoryBeanCustomizerPostProcessor
 		implements BeanPostProcessor, ApplicationContextAware {
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactoryCustomizer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactoryCustomizer.java
@@ -22,8 +22,11 @@ package org.springframework.pulsar.config;
  *
  * @param <T> The message payload type
  * @author Chris Bono
+ * @deprecated since 1.2.0 for removal in 1.4.0 in favor of
+ * {@code org.springframework.boot.autoconfigure.pulsar.PulsarContainerFactoryCustomizer<ConcurrentPulsarListenerContainerFactory<?>>}
  */
 @FunctionalInterface
+@Deprecated(since = "1.2.0", forRemoval = true)
 public interface ConcurrentPulsarListenerContainerFactoryCustomizer<T> {
 
 	/**

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarListenerContainerFactoryCustomizerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarListenerContainerFactoryCustomizerTests.java
@@ -36,6 +36,7 @@ import org.springframework.pulsar.config.ConcurrentPulsarListenerContainerFactor
  *
  * @author Chris Bono
  */
+@SuppressWarnings("removal")
 class ConcurrentPulsarListenerContainerFactoryCustomizerTests {
 
 	@Test

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTxnTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTxnTests.java
@@ -51,6 +51,7 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @author Chris Bono
  */
+@SuppressWarnings("removal")
 class PulsarListenerTxnTests extends PulsarTxnTestsBase {
 
 	@Nested


### PR DESCRIPTION
The purpose of `ConcurrentPulsarListenerContainerFactoryCustomizer` was to customize the Spring Boot auto-configured message container factories. However, Spring Boot has introduced a generic message container factory customizer `PulsarContainerFactoryCustomizer` that removes the need for this customizer.

This commit deprecates the Spring for Apache Pulsar customizer in favor of the Spring Boot provided generic container factory customizer.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
