### PR TITLE
Ensure default topics are fully qualified

### DIFF
--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/listener/PulsarListenerIntegrationTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/listener/PulsarListenerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,7 +160,7 @@ class PulsarListenerIntegrationTests implements PulsarTestContainerSupport {
 			public void listen(String ignored, Consumer<String> consumer) {
 				assertThat(consumer).extracting("conf", InstanceOfAssertFactories.type(ConsumerConfigurationData.class))
 					.satisfies((conf) -> {
-						assertThat(conf.getSingleTopic()).isEqualTo("plit-config-props-topic-dev");
+						assertThat(conf.getSingleTopic()).isEqualTo("persistent://public/default/plit-config-props-topic-dev");
 						assertThat(conf.getSubscriptionType()).isEqualTo(SubscriptionType.Shared);
 						assertThat(conf.getSubscriptionName()).isEqualTo("plit-config-props-subs-dev");
 					});

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/listener/PulsarListenerIntegrationTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/listener/PulsarListenerIntegrationTests.java
@@ -160,7 +160,8 @@ class PulsarListenerIntegrationTests implements PulsarTestContainerSupport {
 			public void listen(String ignored, Consumer<String> consumer) {
 				assertThat(consumer).extracting("conf", InstanceOfAssertFactories.type(ConsumerConfigurationData.class))
 					.satisfies((conf) -> {
-						assertThat(conf.getSingleTopic()).isEqualTo("persistent://public/default/plit-config-props-topic-dev");
+						assertThat(conf.getSingleTopic())
+							.isEqualTo("persistent://public/default/plit-config-props-topic-dev");
 						assertThat(conf.getSubscriptionType()).isEqualTo(SubscriptionType.Shared);
 						assertThat(conf.getSubscriptionName()).isEqualTo("plit-config-props-subs-dev");
 					});


### PR DESCRIPTION
Prior to this commit, only the topics specified on the `@PulsarListener` were being fully qualified in the `DefaultPulsarConsumerFactory`. 
With this change all topics (including the default topics driven by the Spring Boot `spring.pulsar.consumer.topics` config prop) are fully-qualified.
.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
