### PR TITLE
Log a warning when Lambda customizer used

### DIFF
--- a/integration-tests/integration-tests.gradle
+++ b/integration-tests/integration-tests.gradle
@@ -22,8 +22,13 @@ dependencies {
 	intTestImplementation 'org.testcontainers:rabbitmq'
 	intTestImplementation libs.spring.boot.starter.test
 	intTestImplementation libs.spring.boot.starter.amqp
-	intTestImplementation libs.spring.boot.starter.pulsar
-	intTestImplementation libs.spring.boot.starter.pulsar.reactive
+	// Exclude spring-pulsar from boot in order to use current changes in project
+	intTestImplementation(libs.spring.boot.starter.pulsar) {
+		exclude group: "org.springframework.pulsar", module: "spring-pulsar"
+	}
+	intTestImplementation(libs.spring.boot.starter.pulsar.reactive) {
+		exclude group: "org.springframework.pulsar", module: "spring-pulsar-reactive"
+	}
 	intTestImplementation libs.spring.boot.testcontainers
 	intTestRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	intTestRuntimeOnly libs.logback.classic

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/logging/PulsarTemplateLambdaWarnLoggerTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/logging/PulsarTemplateLambdaWarnLoggerTests.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.inttest.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.PulsarContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.pulsar.core.ProducerBuilderCustomizer;
+import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.core.PulsarTemplateCustomizer;
+import org.springframework.pulsar.inttest.logging.PulsarTemplateLambdaWarnLoggerTests.WithWarnLoggerDisabled.WithWarnLoggerDisabledConfig;
+import org.springframework.pulsar.inttest.logging.PulsarTemplateLambdaWarnLoggerTests.WithWarnLoggerIncreasedFrequency.WithWarnLoggerIncreasedFrequencyConfig;
+import org.springframework.pulsar.support.internal.logging.LambdaCustomizerWarnLogger;
+import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
+
+/**
+ * Integration tests that covers {@link LambdaCustomizerWarnLogger} and its usage in
+ * {@link PulsarTemplate} of the following cases: <pre>
+ *  - user customizes the template to disable the warn logger
+ *  - user customizes the template to adjust the warn logger frequency
+ *  - template logs warning when a lambda customizer is used as producer customizer
+ *  - template does not log warning when a non-lambda customizer is used
+ * </pre> The nature of the feature (logging and template customization) lends itself well
+ * to an integration test w/ help of {@link CapturedOutput} and
+ * {@link PulsarTemplateCustomizer}.
+ *
+ * @author Chris Bono
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@ExtendWith(OutputCaptureExtension.class)
+class PulsarTemplateLambdaWarnLoggerTests {
+
+	@SuppressWarnings("unused")
+	@Container
+	@ServiceConnection
+	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage());
+
+	@Nested
+	@SpringBootTest(classes = TestAppConfig.class)
+	@ExtendWith(OutputCaptureExtension.class)
+	class WithWarnLoggerEnabledByDefault {
+
+		@Test
+		void whenLambdaCustomizerIsUsedThenWarningIsLogged(CapturedOutput output,
+				@Autowired PulsarTemplate<String> template) {
+			TestUtils.sendRequestsWithCustomizer("lcwlt-default", 1001, template);
+			TestUtils.assertThatWarningIsLoggedNumTimes(2, output);
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(classes = { TestAppConfig.class, WithWarnLoggerIncreasedFrequencyConfig.class })
+	@ExtendWith(OutputCaptureExtension.class)
+	class WithWarnLoggerIncreasedFrequency {
+
+		@Test
+		void whenLambdaCustomizerIsUsedThenWarningIsLoggedMoreFrequently(CapturedOutput output,
+				@Autowired PulsarTemplate<String> template) {
+			TestUtils.sendRequestsWithCustomizer("lcwlt-adjusted", 1001, template);
+			TestUtils.assertThatWarningIsLoggedNumTimes(11, output);
+		}
+
+		@TestConfiguration(proxyBeanMethods = false)
+		static class WithWarnLoggerIncreasedFrequencyConfig {
+
+			@Bean
+			PulsarTemplateCustomizer<?> templateCustomizer() {
+				return (template) -> template.logWarningForLambdaCustomizer(100);
+			}
+
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(classes = { TestAppConfig.class, WithWarnLoggerDisabledConfig.class })
+	@ExtendWith(OutputCaptureExtension.class)
+	class WithWarnLoggerDisabled {
+
+		@Test
+		void whenLambdaCustomizerIsUsedThenWarningIsNotLogged(CapturedOutput output,
+				@Autowired PulsarTemplate<String> template) {
+			TestUtils.sendRequestsWithCustomizer("lcwlt-disabled", 1001, template);
+			TestUtils.assertThatWarningIsLoggedNumTimes(0, output);
+		}
+
+		@TestConfiguration(proxyBeanMethods = false)
+		static class WithWarnLoggerDisabledConfig {
+
+			@Bean
+			PulsarTemplateCustomizer<?> templateCustomizer() {
+				return (template) -> template.logWarningForLambdaCustomizer(0);
+			}
+
+		}
+
+	}
+
+	@Nested
+	@SpringBootTest(classes = TestAppConfig.class, properties = "spring.pulsar.producer.cache.enabled=false")
+	@ExtendWith(OutputCaptureExtension.class)
+	class WithNonCachingProducerFactory {
+
+		@Test
+		void whenLambdaCustomizerIsUsedThenWarningIsNotLogged(CapturedOutput output,
+				@Autowired PulsarTemplate<String> template) {
+			TestUtils.sendRequestsWithCustomizer("lcwlt-non-caching", 1001, template);
+			TestUtils.assertThatWarningIsLoggedNumTimes(0, output);
+		}
+
+	}
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	static class TestAppConfig {
+
+	}
+
+	private static class TestUtils {
+
+		private static void sendRequestsWithCustomizer(String testPrefix, int numberOfSends,
+				PulsarTemplate<String> template) {
+			sendRequests(testPrefix, numberOfSends, (pb) -> {
+			}, template);
+		}
+
+		private static void sendRequestsWithoutCustomizer(String testPrefix, int numberOfSends,
+				PulsarTemplate<String> template) {
+			sendRequests(testPrefix, numberOfSends, null, template);
+		}
+
+		private static void sendRequests(String testPrefix, int numberOfSends,
+				ProducerBuilderCustomizer<String> customizer, PulsarTemplate<String> template) {
+			for (int i = 0; i < numberOfSends; i++) {
+				var msg = "LambdaCustomizerWarningLog-i:" + i;
+				var builder = template.newMessage(msg).withTopic("%s-topic".formatted(testPrefix));
+				if (customizer != null) {
+					builder.withProducerCustomizer(customizer);
+				}
+				builder.send();
+			}
+		}
+
+		private static void assertThatWarningIsLoggedNumTimes(int expectedNumberOfTimes, CapturedOutput output) {
+			// pause to make sure log is flushed to console before checking (sanity)
+			try {
+				Thread.sleep(1000);
+			}
+			catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+			var pattern = Pattern.compile("(Producer customizer \\[.+?\\] is implemented as a Lambda)");
+			assertThat(output.getAll())
+				.satisfies((outputStr) -> assertThat(pattern.matcher(outputStr).results().count())
+					.isEqualTo(expectedNumberOfTimes));
+		}
+
+	}
+
+}

--- a/integration-tests/src/intTest/resources/logback-test.xml
+++ b/integration-tests/src/intTest/resources/logback-test.xml
@@ -12,4 +12,5 @@
 	<logger name="org.springframework.pulsar.function" level="INFO"/>
 	<logger name="org.springframework.pulsar.inttest.app" level="INFO"/>
 	<logger name="org.springframework.pulsar.inttest.config" level="INFO"/>
+	<logger name="org.springframework.pulsar.inttest.logging" level="INFO"/>
 </configuration>

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/support/JavaUtils.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/support/JavaUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.lang.Nullable;
  * the singleton {@link #INSTANCE} and then chain calls to the utility methods.
  *
  * @author Soby Chacko
+ * @author Chris Bono
  */
 public final class JavaUtils {
 
@@ -48,6 +49,15 @@ public final class JavaUtils {
 			consumer.accept(value);
 		}
 		return this;
+	}
+
+	/**
+	 * Determine if the specified class is a Lambda.
+	 * @param clazz the class to check
+	 * @return whether the specified class is a Lambda
+	 */
+	public boolean isLambda(Class<?> clazz) {
+		return clazz.isSynthetic() && clazz.getName().contains("$$Lambda") && !clazz.isAnonymousClass();
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/support/internal/logging/EveryNthSampler.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/support/internal/logging/EveryNthSampler.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.support.internal.logging;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongPredicate;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.util.Assert;
+
+/**
+ * Decides whether an input should be sampled based on frequency of occurrence.
+ * <p>
+ * Each input is considered sampled on the first and every nth time it is encountered.
+ * <p>
+ * The inputs are tracked in a bounded map whose entries are cleared when it reaches
+ * capacity.
+ *
+ * @param <T> type of input (e.g. String)
+ * @author Chris Bono
+ * @since 1.2.0
+ */
+class EveryNthSampler<T> {
+
+	private final long nth;
+
+	private final long maxInputs;
+
+	private final Map<T, AtomicLong> inputCounters = new ConcurrentHashMap<>();
+
+	private final AtomicLong numInputCounters = new AtomicLong(0);
+
+	private final LogAccessor logger = new LogAccessor(EveryNthSampler.class);
+
+	/**
+	 * Construct a sampler instance.
+	 * @param nth the frequency (i.e. every nth occurrence)
+	 * @param maxInputs the maximum number of inputs to track before clearing the map
+	 */
+	EveryNthSampler(long nth, long maxInputs) {
+		Assert.state(nth > 0, () -> "nth must be a positive value");
+		Assert.state(maxInputs > 0, () -> "maxInputs must be a positive value");
+		this.nth = nth;
+		this.maxInputs = maxInputs;
+	}
+
+	/**
+	 * Determine if the given input should be sampled.
+	 * <p>
+	 * The input is considered sampled on the first and every nth occurrence.
+	 * @param input the input to check
+	 * @return whether the input should be sampled
+	 */
+	boolean trySample(T input) {
+		var initialCounter = new AtomicLong(0);
+		var inputCounter = this.inputCounters.computeIfAbsent(input, (__) -> initialCounter);
+		// When new input added to map, increment and check size and clear if over max
+		if (inputCounter == initialCounter) {
+			this.incrementWithResetAtThreshold(this.numInputCounters, this.maxInputs + 1,
+					Long.valueOf(this.maxInputs)::equals, () -> CompletableFuture.runAsync(() -> {
+						this.logger.debug(() -> "Max inputs (%s) reached - clearing map".formatted(this.maxInputs));
+						this.inputCounters.clear();
+						this.inputCounters.computeIfAbsent(input, (__) -> initialCounter);
+					}));
+		}
+		// Update input counter and mark sampled on 1st and Nth occurrence
+		var sampled = new AtomicBoolean(false);
+		this.incrementWithResetAtThreshold(inputCounter, this.nth, Long.valueOf(0L)::equals, () -> {
+			this.logger.trace(() -> "Input [%s] is sampled".formatted(input));
+			sampled.set(true);
+		});
+		return sampled.get();
+	}
+
+	private void incrementWithResetAtThreshold(AtomicLong counter, long threshold,
+			LongPredicate runActionIfPriorCountMeets, Runnable action) {
+		var priorCount = this.incrementWithResetAtThreshold(counter, threshold);
+		if (runActionIfPriorCountMeets.test(priorCount)) {
+			action.run();
+		}
+	}
+
+	private long incrementWithResetAtThreshold(AtomicLong counter, long threshold) {
+		return counter.getAndUpdate((currentCount) -> ((currentCount + 1) % threshold == 0) ? 0 : currentCount + 1);
+	}
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/support/internal/logging/LambdaCustomizerWarnLogger.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/support/internal/logging/LambdaCustomizerWarnLogger.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.support.internal.logging;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.pulsar.core.ProducerBuilderCustomizer;
+import org.springframework.pulsar.support.JavaUtils;
+import org.springframework.util.Assert;
+
+/**
+ * Log a warning when a Lambda is used as a producer builder customizer.
+ * <p>
+ * For each encountered Lambda customizer, the log is sampled on a frequency to avoid
+ * flooding the logs. The warning is logged on the very first occurrence and then every
+ * nth time thereafter.
+ *
+ * @author Chris Bono
+ * @since 1.2.0
+ */
+public class LambdaCustomizerWarnLogger {
+
+	private static final String CUSTOMIZER_LAMBDA_MSG = """
+			Producer customizer [%s] is implemented as a Lambda. If you are experiencing write performance degradation
+			it may be related to cache misses if the lambda is not following the rules outlined in
+			https://docs.spring.io/spring-pulsar/reference/reference/pulsar/message-production.html#producer-caching-lambdas""";
+
+	private final LogAccessor logger;
+
+	private final EveryNthSampler<String> logSampler;
+
+	/**
+	 * Construct an instance.
+	 * @param logger the backing logger
+	 * @param frequency how often to log the warning (i.e. {@code every nth occurrence})
+	 * @see EveryNthSampler
+	 */
+	public LambdaCustomizerWarnLogger(LogAccessor logger, long frequency) {
+		Assert.notNull(logger, "logger must not be null");
+		this.logger = logger;
+		this.logSampler = new EveryNthSampler<>(frequency, 500);
+	}
+
+	/**
+	 * Log a warning if the given customizer is implemented as a Lambda.
+	 * <p>
+	 * Note that the log is sampled and will be logged on the very first and every nth
+	 * occurrence thereafter.
+	 * @param producerCustomizer the customizer
+	 */
+	public void maybeLog(ProducerBuilderCustomizer<?> producerCustomizer) {
+		var customizerClass = producerCustomizer.getClass();
+		if (JavaUtils.INSTANCE.isLambda(customizerClass) && this.logSampler.trySample(customizerClass.getName())) {
+			this.logger.warn(() -> CUSTOMIZER_LAMBDA_MSG.formatted(customizerClass.getName()));
+		}
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/support/JavaUtilsTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/support/JavaUtilsTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link JavaUtils}.
+ */
+public class JavaUtilsTests {
+
+	@Nested
+	class IsLambdaApi {
+
+		@Test
+		void returnsTrueForLambda() {
+			Consumer<String> lambdaConsumer = (__) -> {
+			};
+			assertThat(JavaUtils.INSTANCE.isLambda(lambdaConsumer.getClass())).isTrue();
+		}
+
+		@Test
+		void returnsFalseForTopLevelClass() {
+			assertThat(JavaUtils.INSTANCE.isLambda(String.class)).isFalse();
+		}
+
+		@Test
+		void returnsFalseForStaticNestedClass() {
+			assertThat(JavaUtils.INSTANCE.isLambda(StaticNestedClass.class)).isFalse();
+		}
+
+		@Test
+		void returnsFalseForNonLambdaConsumer() {
+			assertThat(JavaUtils.INSTANCE.isLambda(NonLambdaConsumer.class)).isFalse();
+		}
+
+		@Test
+		void returnsFalseForAnonymousConsumer() {
+			var anonymousConsumer = new Consumer<String>() {
+				@Override
+				public void accept(String s) {
+				}
+			};
+			assertThat(JavaUtils.INSTANCE.isLambda(anonymousConsumer.getClass())).isFalse();
+		}
+
+		static class StaticNestedClass {
+
+		}
+
+		static class NonLambdaConsumer implements Consumer<String> {
+
+			@Override
+			public void accept(String s) {
+			}
+
+		}
+
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/support/internal/logging/EveryNthSamplerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/support/internal/logging/EveryNthSamplerTests.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.support.internal.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for {@link EveryNthSampler}.
+ */
+class EveryNthSamplerTests {
+
+	@Test
+	void singleInputInvokesEveryNth() {
+		var counter = new AtomicInteger(0);
+		var sampler = new EveryNthSampler<String>(5, 1000);
+		var input1 = "abc";
+		// invoke on 1st
+		incrementCounterIfSampled(counter, sampler, input1);
+		assertThat(counter).hasValue(1);
+		// do not invoke on 2nd-4th
+		IntStream.range(0, 4).forEach((__) -> incrementCounterIfSampled(counter, sampler, input1));
+		assertThat(counter).hasValue(1);
+		// invoke on 5th
+		incrementCounterIfSampled(counter, sampler, input1);
+		assertThat(counter).hasValue(2);
+		// do not invoke on 6th-9th
+		IntStream.range(0, 4).forEach((__) -> incrementCounterIfSampled(counter, sampler, input1));
+		assertThat(counter).hasValue(2);
+		// invoke on 10th
+		incrementCounterIfSampled(counter, sampler, input1);
+		assertThat(counter).hasValue(3);
+	}
+
+	@Test
+	void multiInputsInvokeEveryNth() {
+		var input1 = "abc";
+		var input2 = "def";
+		var counter1 = new AtomicInteger(0);
+		var counter2 = new AtomicInteger(0);
+		var sampler = new EveryNthSampler<String>(5, 1000);
+		IntStream.range(0, 20).forEach((__) -> {
+			incrementCounterIfSampled(counter1, sampler, input1);
+			incrementCounterIfSampled(counter2, sampler, input2);
+		});
+		assertThat(counter1).hasValue(4);
+		assertThat(counter2).hasValue(4);
+	}
+
+	@Test
+	void invokeOnEveryCall() {
+		var counter = new AtomicInteger(0);
+		var sampler = new EveryNthSampler<String>(1, 1000);
+		IntStream.range(0, 10).forEach((__) -> incrementCounterIfSampled(counter, sampler, "abc"));
+		assertThat(counter).hasValue(10);
+	}
+
+	@Test
+	void whenMaxInputsThenMapIsCleared() {
+		var input1 = "aaa";
+		var input2 = "bbb";
+		var input3 = "ccc";
+		var counter1 = new AtomicInteger(0);
+		var counter2 = new AtomicInteger(0);
+		var counter3 = new AtomicInteger(0);
+		var sampler = new EveryNthSampler<String>(3, 2);
+		// Put at max capacity 2
+		incrementCounterIfSampled(counter1, sampler, input1);
+		incrementCounterIfSampled(counter2, sampler, input2);
+		// Force map clear by going over capacity w/ 3rd entry
+		incrementCounterIfSampled(counter3, sampler, input3);
+		assertThat(counter3).hasValue(1);
+		// Wait for the map to clear async and be sure the new counter remains
+		Awaitility.await()
+			.atMost(Duration.ofSeconds(5))
+			.untilAsserted(() -> assertThat(sampler)
+				.extracting("inputCounters", InstanceOfAssertFactories.map(String.class, AtomicLong.class))
+				.containsOnlyKeys(input3));
+		// The side effect is the cleared entries will fire again as their counter is
+		// effectively reset
+		incrementCounterIfSampled(counter1, sampler, input1);
+		assertThat(counter1).hasValue(2);
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { 0, -1 })
+	void frequencyMustBePositive(long frequency) {
+		assertThatIllegalStateException().isThrownBy(() -> new EveryNthSampler<>(frequency, 500))
+			.withMessage("nth must be a positive value");
+	}
+
+	@ParameterizedTest
+	@ValueSource(longs = { 0, -1 })
+	void maxInputsMustBePositive(long maxInput) {
+		assertThatIllegalStateException().isThrownBy(() -> new EveryNthSampler<>(100, maxInput))
+			.withMessage("maxInputs must be a positive value");
+	}
+
+	private <T> void incrementCounterIfSampled(AtomicInteger counter, EveryNthSampler<T> sampler, T input) {
+		if (sampler.trySample(input)) {
+			counter.incrementAndGet();
+		}
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/support/internal/logging/LambdaCustomizerWarnLoggerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/support/internal/logging/LambdaCustomizerWarnLoggerTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.support.internal.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.function.Supplier;
+
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.pulsar.core.ProducerBuilderCustomizer;
+
+/**
+ * Tests for {@link LambdaCustomizerWarnLogger}.
+ */
+class LambdaCustomizerWarnLoggerTests {
+
+	@Test
+	void whenConstructedThenSamplerCreatedWithFrequency() {
+		var logger = new LogAccessor(this.getClass());
+		var warnLogger = new LambdaCustomizerWarnLogger(logger, 5);
+		assertThat(warnLogger).extracting("logSampler", InstanceOfAssertFactories.type(EveryNthSampler.class))
+			.satisfies((sampler) -> {
+				assertThat(sampler).hasFieldOrPropertyWithValue("nth", 5L);
+				assertThat(sampler).hasFieldOrPropertyWithValue("maxInputs", 500L);
+			});
+	}
+
+	@Test
+	void whenCustomizerIsLambdaThenWarningIsLogged() {
+		var logger = mock(LogAccessor.class);
+		var warnLogger = new LambdaCustomizerWarnLogger(logger, 5);
+		ProducerBuilderCustomizer<String> lambdaCustomizer = (__) -> {
+		};
+		warnLogger.maybeLog(lambdaCustomizer);
+		var logMsgPrefix = "Producer customizer [%s] is implemented as a Lambda."
+			.formatted(lambdaCustomizer.getClass().getName());
+		ArgumentMatcher<Supplier<String>> argMatcher = (s) -> s.get().startsWith(logMsgPrefix);
+		verify(logger).warn(argThat(argMatcher));
+	}
+
+	@Test
+	void whenCustomizerIsNotLambdaThenWarningIsNotLogged() {
+		var logger = mock(LogAccessor.class);
+		var warnLogger = new LambdaCustomizerWarnLogger(logger, 5);
+		warnLogger.maybeLog(new NonLambdaCustomizer());
+		verifyNoInteractions(logger);
+	}
+
+	static class NonLambdaCustomizer implements ProducerBuilderCustomizer<String> {
+
+		@Override
+		public void customize(ProducerBuilder<String> producerBuilder) {
+
+		}
+
+	}
+
+}

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -8,9 +8,7 @@
 	<suppress files="DefaultSchemaResolverTests" checks="MethodParamPad" />
 	<suppress files="PulsarFunctionAdministrationIntegrationTests" checks="Regexp" />
 	<suppress files="Proto" checks=".*"/>
-	<suppress files="ReactiveSpringPulsarBootApp" checks="HideUtilityClassConstructor"/>
-	<suppress files="SamplePulsarApplicationTests" checks="HideUtilityClassConstructor" />
-	<suppress files="DefaultTenantAndNamespaceTests" checks="HideUtilityClassConstructor" />
+	<suppress files=".*Tests" checks="HideUtilityClassConstructor" />
 	<suppress files="[\\/]spring-pulsar-docs[\\/]" checks="JavadocPackage|JavadocType|JavadocVariable|SpringDeprecatedCheck" />
 	<suppress files="[\\/]spring-pulsar-docs[\\/]" checks="SpringJavadoc" message="\@since" />
 	<suppress files="[\\/]spring-pulsar-docs[\\/].*jooq" checks="AvoidStaticImport" />


### PR DESCRIPTION
This adjusts the `PulsarTemplate` to log a warning when a user provides a `ProducerBuilderCustomizer` that is implemented as a Java Lambda. This is important as the customizer is used as part of the producer cache key and if not implemented properly will effectively disable producer caching and write performance will degrade.

See #809

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
