### PR TITLE
Specify locale in toLowerCase|toUpperCase

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/function/PulsarFunctionAdministration.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/function/PulsarFunctionAdministration.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -314,7 +315,7 @@ public class PulsarFunctionAdministration implements SmartLifecycle {
 	}
 
 	private String functionDesc(PulsarFunctionOperations<?> function) {
-		return "'%s' %s".formatted(function.name(), function.type().toString().toLowerCase());
+		return "'%s' %s".formatted(function.name(), function.type().toString().toLowerCase(Locale.ROOT));
 	}
 
 	/**

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/support/header/PulsarHeaderMatcher.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/support/header/PulsarHeaderMatcher.java
@@ -16,6 +16,7 @@
 
 package org.springframework.pulsar.support.header;
 
+import java.util.Locale;
 import java.util.Set;
 
 import org.springframework.core.log.LogAccessor;
@@ -92,13 +93,13 @@ public interface PulsarHeaderMatcher {
 
 		public PatternMatch(String pattern, boolean negate) {
 			Assert.notNull(pattern, "Pattern must not be null");
-			this.pattern = pattern.toLowerCase();
+			this.pattern = pattern.toLowerCase(Locale.ROOT);
 			this.negate = negate;
 		}
 
 		@Override
 		public boolean matchHeader(String headerName) {
-			if (!PatternMatchUtils.simpleMatch(this.pattern, headerName.toLowerCase())) {
+			if (!PatternMatchUtils.simpleMatch(this.pattern, headerName.toLowerCase(Locale.ROOT))) {
 				return false;
 			}
 			LOGGER.debug(() -> "headerName=[%s] WILL %s be mapped, matched pattern=%s".formatted(headerName,

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -8,8 +8,10 @@
 	<suppress files="DefaultSchemaResolverTests" checks="MethodParamPad" />
 	<suppress files="PulsarFunctionAdministrationIntegrationTests" checks="Regexp" />
 	<suppress files="Proto" checks=".*"/>
+	<suppress files=".*Tests" checks="HideUtilityClassConstructor" />
+	<suppress files=".*Tests" checks="RegexpSinglelineJava" id="toLowerCaseWithoutLocale"/>
+	<suppress files=".*Tests" checks="RegexpSinglelineJava" id="toUpperCaseWithoutLocale"/>
 	<suppress files="ReactiveSpringPulsarBootApp" checks="HideUtilityClassConstructor"/>
-	<suppress files="SamplePulsarApplicationTests" checks="HideUtilityClassConstructor" />
 	<suppress files="[\\/]spring-pulsar-docs[\\/]" checks="JavadocPackage|JavadocType|JavadocVariable|SpringDeprecatedCheck" />
 	<suppress files="[\\/]spring-pulsar-docs[\\/]" checks="SpringJavadoc" message="\@since" />
 	<suppress files="[\\/]spring-pulsar-docs[\\/].*jooq" checks="AvoidStaticImport" />

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -169,6 +169,22 @@
 					  value="Please use AssertJ imports."/>
 			<property name="ignoreComments" value="true"/>
 		</module>
+		<module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">
+			<property name="id" value="toLowerCaseWithoutLocale"/>
+			<property name="format" value="\.toLowerCase\(\)"/>
+			<property name="maximum" value="0"/>
+			<property name="message"
+					  value="String.toLowerCase() should be String.toLowerCase(Locale.ROOT)"/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+		<module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">
+			<property name="id" value="toUpperCaseWithoutLocale"/>
+			<property name="format" value="\.toUpperCase\(\)"/>
+			<property name="maximum" value="0"/>
+			<property name="message"
+					  value="String.toUpperCase() should be String.toUpperCase(Locale.ROOT)"/>
+			<property name="ignoreComments" value="true"/>
+		</module>
 		<module name="Regexp">
 			<property name="format" value="[ \t]+$"/>
 			<property name="illegalPattern" value="true"/>


### PR DESCRIPTION
This commit makes sure that all usages of String toLowerCase and toUpperCase specify a Locale (default of Locale.ROOT).

Also, a checkstyle rule is added to prevent usage of the no-arg variant of String toLowerCase and toUpperCase.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
