### PR TITLE
Remove version 0.2.x from docs

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/appendix/version-compatibility.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/appendix/version-compatibility.adoc
@@ -25,17 +25,11 @@ The following is the compatibility matrix:
 | 3.2.x
 | 17+
 
-| 0.2.x
-| 2.11.x
-| 0.2.x
-| 3.0.x / 3.1.x^**(*)**^
-| 17+
 |===
 
 [NOTE]
 ====
-In version `1.0.0` the autoconfiguration moved into Spring Boot `3.2.x` and therefore `3.2.x` is the minimum Spring Boot version supported when using version `1.0.x` of the framework.
-
-However, prior to version `1.0.0`, the autoconfiguration support exists in the framework itself.
-^**(*)**^This makes it theoretically possible to use later versions of Spring Boot besides `3.0.x` which it is tested against and guaranteed to work with. In other words, it may work with `3.1.x` but it has not been tested against it.
+If you are currently using Pulsar `2.11.x` you may notice that it is not present in the above matrix.
+We do not currently test nor officially support running against Pulsar `2.11.x`.
+However, Pulsar is currently compatible across versions and it is likely to work for you.
 ====


### PR DESCRIPTION
This commit removes version 0.2.x from the compatibility matrix in an effort to curb the current use of version 0.2.x.

<img width="1110" alt="Screenshot 2024-11-12 at 13 42 08" src="https://github.com/user-attachments/assets/a0b5939e-864b-4a52-b34d-79a24865ea10">


<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
