### PR TITLE
Add Pulsar 4.0.x compatibility tests

### DIFF
--- a/.github/workflows/check-samples.yml
+++ b/.github/workflows/check-samples.yml
@@ -20,6 +20,7 @@ jobs:
       runjobs: ${{ steps.continue.outputs.runjobs }}
       project_version: ${{ steps.continue.outputs.project_version }}
       boot_version: ${{ steps.continue.outputs.boot_version }}
+      pulsar_version: ${{ steps.continue.outputs.pulsar_version }}
     steps:
       - uses: actions/checkout@v4
       - id: continue
@@ -32,6 +33,8 @@ jobs:
           echo "project_version=$version" >>$GITHUB_OUTPUT
           bootVersion=$(cat gradle/libs.versions.toml | grep "spring-boot = \"" | cut -d '"' -f2)
           echo "boot_version=$bootVersion" >>$GITHUB_OUTPUT
+          pulsarVersion=$(cat gradle/libs.versions.toml | grep "pulsar = \"" | cut -d '"' -f2)
+          echo "pulsar_version=$pulsarVersion" >>$GITHUB_OUTPUT
   check_samples:
     name: Check Samples project
     needs: [prerequisites]
@@ -41,14 +44,37 @@ jobs:
           - javaVersion: 17
             springBootVersion: "${{ needs.prerequisites.outputs.boot_version }}"
             springPulsarVersion: "${{ needs.prerequisites.outputs.project_version }}"
+            pulsarVersion: "${{ needs.prerequisites.outputs.pulsar_version }}"
             samplesTarget: ':runAllSampleTests'
           - javaVersion: 21
             springBootVersion: "${{ needs.prerequisites.outputs.boot_version }}"
             springPulsarVersion: "${{ needs.prerequisites.outputs.project_version }}"
+            pulsarVersion: "${{ needs.prerequisites.outputs.pulsar_version }}"
             samplesTarget: ':runAllSampleTests -x :spring-pulsar-sample-apps:sample-pulsar-functions:sample-signup-function:test'
           - javaVersion: 17
-            springBootVersion: "3.2.3-SNAPSHOT"
-            springPulsarVersion: "1.0.0-SNAPSHOT"
+            springBootVersion: "${{ needs.prerequisites.outputs.boot_version }}"
+            springPulsarVersion: "${{ needs.prerequisites.outputs.project_version }}"
+            pulsarVersion: "3.2.4"
+            samplesTarget: ':runAllSampleTests'
+          - javaVersion: 17
+            springBootVersion: "${{ needs.prerequisites.outputs.boot_version }}"
+            springPulsarVersion: "${{ needs.prerequisites.outputs.project_version }}"
+            pulsarVersion: "4.0.1"
+            samplesTarget: ':runAllSampleTests'
+          - javaVersion: 17
+            springBootVersion: "3.3.7-SNAPSHOT"
+            springPulsarVersion: "1.1.7-SNAPSHOT"
+            pulsarVersion: "3.2.4"
+            samplesTarget: ':runAllSampleTests'
+          - javaVersion: 17
+            springBootVersion: "3.3.7-SNAPSHOT"
+            springPulsarVersion: "1.1.7-SNAPSHOT"
+            pulsarVersion: "3.3.3"
+            samplesTarget: ':runAllSampleTests'
+          - javaVersion: 17
+            springBootVersion: "3.3.7-SNAPSHOT"
+            springPulsarVersion: "1.1.7-SNAPSHOT"
+            pulsarVersion: "4.0.1"
             samplesTarget: ':runAllSampleTests'
     runs-on: ubuntu-latest
     if: needs.prerequisites.outputs.runjobs
@@ -60,6 +86,7 @@ jobs:
           LOCAL_REPOSITORY_PATH: ${{ github.workspace }}/build/publications/repos
           VERSION: ${{ matrix.springPulsarVersion }}
           BOOT_VERSION: ${{ matrix.springBootVersion }}
+          PULSAR_VERSION: ${{ matrix.pulsarVersion }}
           JAVA_VERSION: ${{ matrix.javaVersion }}
         run: |
           ./gradlew publishMavenJavaPublicationToLocalRepository
@@ -68,6 +95,7 @@ jobs:
             -PlocalRepositoryPath="$LOCAL_REPOSITORY_PATH" \
             -PspringPulsarVersion="$VERSION" \
             -PspringBootVersion="$BOOT_VERSION" \
+            -PpulsarVersion="$PULSAR_VERSION" \
             -PtestToolchain="$JAVA_VERSION" \
             -PsampleTests \
             ${{ matrix.samplesTarget }}

--- a/spring-pulsar-sample-apps/sample-failover-custom-router/build.gradle
+++ b/spring-pulsar-sample-apps/sample-failover-custom-router/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 def versionCatalog = extensions.getByType(VersionCatalogsExtension).named("libs")
-def pulsarVersion = versionCatalog.findVersion("pulsar").orElseThrow().displayName
+def pulsarVersion = project.properties['pulsarVersion'] ?: versionCatalog.findVersion("pulsar").orElseThrow().displayName
 
 ext['spring-pulsar.version'] = "${project.property('version.samples')}"
 ext['pulsar.version'] = "${pulsarVersion}"

--- a/spring-pulsar-sample-apps/sample-imperative-produce-consume/build.gradle
+++ b/spring-pulsar-sample-apps/sample-imperative-produce-consume/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 def versionCatalog = extensions.getByType(VersionCatalogsExtension).named("libs")
-def pulsarVersion = versionCatalog.findVersion("pulsar").orElseThrow().displayName
+def pulsarVersion = project.properties['pulsarVersion'] ?: versionCatalog.findVersion("pulsar").orElseThrow().displayName
 
 ext['spring-pulsar.version'] = "${project.property('version.samples')}"
 ext['pulsar.version'] = "${pulsarVersion}"

--- a/spring-pulsar-sample-apps/sample-pulsar-binder/build.gradle
+++ b/spring-pulsar-sample-apps/sample-pulsar-binder/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 def versionCatalog = extensions.getByType(VersionCatalogsExtension).named("libs")
-def pulsarVersion = versionCatalog.findVersion("pulsar").orElseThrow().displayName
+def pulsarVersion = project.properties['pulsarVersion'] ?: versionCatalog.findVersion("pulsar").orElseThrow().displayName
 def springCloudStreamVersion = versionCatalog.findVersion("spring-cloud-stream").orElseThrow().displayName
 
 ext['spring-pulsar.version'] = "${project.property('version.samples')}"

--- a/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-app/build.gradle
+++ b/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-app/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 def versionCatalog = extensions.getByType(VersionCatalogsExtension).named("libs")
 def springCloudStreamVersion = versionCatalog.findVersion("spring-cloud-stream").orElseThrow().displayName
-def pulsarVersion = versionCatalog.findVersion("pulsar").orElseThrow().displayName
+def pulsarVersion = project.properties['pulsarVersion'] ?: versionCatalog.findVersion("pulsar").orElseThrow().displayName
 
 ext['spring-pulsar.version'] = "${project.property('version.samples')}"
 ext['pulsar.version'] = "${pulsarVersion}"

--- a/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-function/build.gradle
+++ b/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-function/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 def versionCatalog = extensions.getByType(VersionCatalogsExtension).named("libs")
-def pulsarVersion = versionCatalog.findVersion("pulsar").orElseThrow().displayName
+def pulsarVersion = project.properties['pulsarVersion'] ?: versionCatalog.findVersion("pulsar").orElseThrow().displayName
 
 dependencies {
 	implementation "org.apache.pulsar:pulsar-client-all:${pulsarVersion}"

--- a/spring-pulsar-sample-apps/sample-pulsar-reader/build.gradle
+++ b/spring-pulsar-sample-apps/sample-pulsar-reader/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 def versionCatalog = extensions.getByType(VersionCatalogsExtension).named("libs")
-def pulsarVersion = versionCatalog.findVersion("pulsar").orElseThrow().displayName
+def pulsarVersion = project.properties['pulsarVersion'] ?: versionCatalog.findVersion("pulsar").orElseThrow().displayName
 
 ext['spring-pulsar.version'] = "${project.property('version.samples')}"
 ext['pulsar.version'] = "${pulsarVersion}"

--- a/spring-pulsar-sample-apps/sample-reactive/build.gradle
+++ b/spring-pulsar-sample-apps/sample-reactive/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 def versionCatalog = extensions.getByType(VersionCatalogsExtension).named("libs")
-def pulsarVersion = versionCatalog.findVersion("pulsar").orElseThrow().displayName
+def pulsarVersion = project.properties['pulsarVersion'] ?: versionCatalog.findVersion("pulsar").orElseThrow().displayName
 def pulsarReactiveVersion = versionCatalog.findVersion("pulsar-reactive").orElseThrow().displayName
 
 ext['spring-pulsar.version'] = "${project.property('version.samples')}"


### PR DESCRIPTION
Adds the ability to specify the Pulsar client version when running the samples apps.
Uses this new capability to add entries to the `check-samples.yml` compatibility test matrix to include Pulsar 4.0.x.

See #923

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
