### PR TITLE
Backport "Fix batch listener error handling" (1.0.x)

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
@@ -593,12 +593,11 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 						pulsarBatchListenerFailedException);
 				handleAck(pulsarMessage);
 				if (messageList.size() == 1) {
+					messageList.remove(0);
 					messagesPendingInBatch.set(false);
 				}
 				else {
 					messageList = messageList.subList(1, messageList.size());
-				}
-				if (!messageList.isEmpty()) {
 					messagesPendingInBatch.set(true);
 				}
 				this.pulsarConsumerErrorHandler.clearMessage();


### PR DESCRIPTION
Updates the batch listener error handler code to handle the case where there is only a single outstanding
message in the batch list when retries are expired.

See #998

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
