### PR TITLE
Allow pulsar metadata headers to be mapped outbound

### DIFF
--- a/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar-header.adoc
+++ b/spring-pulsar-docs/src/main/antora/modules/ROOT/pages/reference/pulsar-header.adoc
@@ -63,9 +63,9 @@ static class PulsarHeadersCustomObjectMapperTestConfig {
 
 === Inbound/Outbound Patterns
 On the inbound side, by default, all Pulsar headers (message metadata plus user properties) are mapped to `MessageHeaders`.
-On the outbound side, by default, all `MessageHeaders` are mapped, except `id`, `timestamp`, and the headers that represent the Pulsar message metadata.
+On the outbound side, by default, all `MessageHeaders` are mapped, except `id`, `timestamp`, and the headers that represent the Pulsar message metadata (i.e. the headers that are prefixed with `pulsar_message_`).
 You can specify which headers are mapped for inbound and outbound messages by configuring the `inboundPatterns` and `outboundPatterns` on a mapper bean you provide.
-
+You can include Pulsar message metadata headers on the outbound messages by adding the exact header name to the `outboundPatterns` as patterns are not supported for metadata headers.
 Patterns are rather simple and can contain a leading wildcard (`\*`), a trailing wildcard, or both (for example, `*.cat.*`).
 You can negate patterns with a leading `!`.
 The first pattern that matches a header name (whether positive or negative) wins.

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/support/header/AbstractPulsarHeaderMapperTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/support/header/AbstractPulsarHeaderMapperTests.java
@@ -28,6 +28,7 @@ import static org.springframework.pulsar.support.header.PulsarHeaderMapperTestUt
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.pulsar.client.api.Message;
@@ -206,6 +207,19 @@ abstract class AbstractPulsarHeaderMapperTests {
 			verify(spyTestMapper, times(springHeaders.size())).matchesForOutbound(anyString());
 		}
 
+		@Test
+		void neverMatchFiltersCanBeConfigured() {
+			var mapper = mapperWithOutboundPatterns(PulsarHeaders.KEY, PulsarHeaders.MESSAGE_ID,
+					PulsarHeaders.PRODUCER_NAME, "noSuchInternalHeader");
+			var springHeaders = new HashMap<String, Object>();
+			springHeaders.put(PulsarHeaders.KEY, "testKey");
+			springHeaders.put(PulsarHeaders.KEY_BYTES, "testKeyBytes");
+			springHeaders.put(PulsarHeaders.MESSAGE_ID, "testMsg");
+			springHeaders.put(PulsarHeaders.PRODUCER_NAME, "testProducer");
+			assertThat(mapper.toPulsarHeaders(new MessageHeaders(springHeaders))).containsOnlyKeys(PulsarHeaders.KEY,
+					PulsarHeaders.MESSAGE_ID, PulsarHeaders.PRODUCER_NAME);
+		}
+
 	}
 
 	@Nested
@@ -249,7 +263,7 @@ abstract class AbstractPulsarHeaderMapperTests {
 		private String toPulsarHeadersContext;
 
 		TestPulsarHeaderMapper(String toSpringHeadersContext, String toPulsarHeadersContext) {
-			super(Collections.emptyList(), Collections.emptyList());
+			super(List.of(), List.of());
 			this.toSpringHeadersContext = toSpringHeadersContext;
 			this.toPulsarHeadersContext = toPulsarHeadersContext;
 		}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/support/header/ToStringPulsarHeaderMapperTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/support/header/ToStringPulsarHeaderMapperTests.java
@@ -19,7 +19,6 @@ package org.springframework.pulsar.support.header;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.pulsar.support.header.PulsarHeaderMapperTestUtil.mockPulsarMessage;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,12 +42,12 @@ class ToStringPulsarHeaderMapperTests extends AbstractPulsarHeaderMapperTests {
 
 	@Override
 	AbstractPulsarHeaderMapper<?, ?> mapperWithInboundPatterns(String... patterns) {
-		return new ToStringPulsarHeaderMapper(List.of(patterns), Collections.emptyList());
+		return new ToStringPulsarHeaderMapper(List.of(patterns), List.of());
 	}
 
 	@Override
 	AbstractPulsarHeaderMapper<?, ?> mapperWithOutboundPatterns(String... patterns) {
-		return new ToStringPulsarHeaderMapper(Collections.emptyList(), List.of(patterns));
+		return new ToStringPulsarHeaderMapper(List.of(), List.of(patterns));
 	}
 
 	@Test


### PR DESCRIPTION
This allows pulsar metadata headers, which are excluded on the outbound messages by default, to be included in the outbound message headers.

Resolves #1037

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
