### PR TITLE
Fix deprecation AssertJ calls

### DIFF
--- a/spring-pulsar/src/test/java/org/springframework/pulsar/function/PulsarFunctionAdministrationTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/function/PulsarFunctionAdministrationTests.java
@@ -228,8 +228,8 @@ class PulsarFunctionAdministrationTests {
 			void firstProcessedFunctionFails() throws PulsarAdminException {
 				var ex = new PulsarAdminException("BOOM");
 				when(function1.functionExists(pulsarAdmin)).thenThrow(ex);
-				var thrown = catchThrowableOfType(() -> functionAdmin.createOrUpdateUserDefinedFunctions(),
-						PulsarFunctionException.class);
+				var thrown = catchThrowableOfType(PulsarFunctionException.class,
+						() -> functionAdmin.createOrUpdateUserDefinedFunctions());
 				assertThat(thrown.getFailures()).containsExactly(entry(function1, ex));
 				verify(function1, never()).create(pulsarAdmin);
 				verify(function1, never()).update(pulsarAdmin);
@@ -241,8 +241,8 @@ class PulsarFunctionAdministrationTests {
 			void middleProcessedFunctionFails() throws PulsarAdminException {
 				var ex = new PulsarAdminException("BOOM");
 				when(sink1.functionExists(pulsarAdmin)).thenThrow(ex);
-				var thrown = catchThrowableOfType(() -> functionAdmin.createOrUpdateUserDefinedFunctions(),
-						PulsarFunctionException.class);
+				var thrown = catchThrowableOfType(PulsarFunctionException.class,
+						() -> functionAdmin.createOrUpdateUserDefinedFunctions());
 				assertThat(thrown.getFailures()).containsExactly(entry(sink1, ex));
 				verify(function1).create(pulsarAdmin);
 				verify(sink1, never()).create(pulsarAdmin);
@@ -255,8 +255,8 @@ class PulsarFunctionAdministrationTests {
 			void lastProcessedFunctionFails() throws PulsarAdminException {
 				var ex = new PulsarAdminException("BOOM");
 				when(source1.functionExists(pulsarAdmin)).thenThrow(ex);
-				var thrown = catchThrowableOfType(() -> functionAdmin.createOrUpdateUserDefinedFunctions(),
-						PulsarFunctionException.class);
+				var thrown = catchThrowableOfType(PulsarFunctionException.class,
+						() -> functionAdmin.createOrUpdateUserDefinedFunctions());
 				assertThat(thrown.getFailures()).containsExactly(entry(source1, ex));
 				verify(function1).create(pulsarAdmin);
 				verify(sink1).create(pulsarAdmin);
@@ -282,8 +282,8 @@ class PulsarFunctionAdministrationTests {
 			void firstProcessedFunctionFails() throws PulsarAdminException {
 				var ex = new PulsarAdminException("BOOM");
 				when(function1.functionExists(pulsarAdmin)).thenThrow(ex);
-				var thrown = catchThrowableOfType(() -> functionAdmin.createOrUpdateUserDefinedFunctions(),
-						PulsarFunctionException.class);
+				var thrown = catchThrowableOfType(PulsarFunctionException.class,
+						() -> functionAdmin.createOrUpdateUserDefinedFunctions());
 				assertThat(thrown.getFailures()).containsExactly(entry(function1, ex));
 				verify(function1, never()).create(pulsarAdmin);
 				verify(function1, never()).update(pulsarAdmin);
@@ -296,8 +296,8 @@ class PulsarFunctionAdministrationTests {
 			void middleProcessedFunctionFails() throws PulsarAdminException {
 				var ex = new PulsarAdminException("BOOM");
 				when(sink1.functionExists(pulsarAdmin)).thenThrow(ex);
-				var thrown = catchThrowableOfType(() -> functionAdmin.createOrUpdateUserDefinedFunctions(),
-						PulsarFunctionException.class);
+				var thrown = catchThrowableOfType(PulsarFunctionException.class,
+						() -> functionAdmin.createOrUpdateUserDefinedFunctions());
 				assertThat(thrown.getFailures()).containsExactly(entry(sink1, ex));
 				verify(function1).create(pulsarAdmin);
 				verify(sink1, never()).create(pulsarAdmin);
@@ -310,8 +310,8 @@ class PulsarFunctionAdministrationTests {
 			void lastProcessedFunctionFails() throws PulsarAdminException {
 				var ex = new PulsarAdminException("BOOM");
 				when(source1.functionExists(pulsarAdmin)).thenThrow(ex);
-				var thrown = catchThrowableOfType(() -> functionAdmin.createOrUpdateUserDefinedFunctions(),
-						PulsarFunctionException.class);
+				var thrown = catchThrowableOfType(PulsarFunctionException.class,
+						() -> functionAdmin.createOrUpdateUserDefinedFunctions());
 				assertThat(thrown.getFailures()).containsExactly(entry(source1, ex));
 				verify(function1).create(pulsarAdmin);
 				verify(sink1).create(pulsarAdmin);
@@ -328,8 +328,8 @@ class PulsarFunctionAdministrationTests {
 				when(function1.functionExists(pulsarAdmin)).thenThrow(ex1);
 				when(sink1.functionExists(pulsarAdmin)).thenThrow(ex2);
 				when(source1.functionExists(pulsarAdmin)).thenThrow(ex3);
-				var thrown = catchThrowableOfType(() -> functionAdmin.createOrUpdateUserDefinedFunctions(),
-						PulsarFunctionException.class);
+				var thrown = catchThrowableOfType(PulsarFunctionException.class,
+						() -> functionAdmin.createOrUpdateUserDefinedFunctions());
 				assertThat(thrown.getFailures()).containsExactly(entry(function1, ex1), entry(sink1, ex2),
 						entry(source1, ex3));
 				verify(function1, never()).create(pulsarAdmin);
@@ -474,8 +474,8 @@ class PulsarFunctionAdministrationTests {
 		void firstProcessedFunctionFails() {
 			var ex = new PulsarException("BOOM");
 			doThrow(ex).when(source1).stop(pulsarAdmin);
-			var thrown = catchThrowableOfType(() -> functionAdmin.enforceStopPolicyOnUserDefinedFunctions(),
-					PulsarFunctionException.class);
+			var thrown = catchThrowableOfType(PulsarFunctionException.class,
+					() -> functionAdmin.enforceStopPolicyOnUserDefinedFunctions());
 			assertThat(thrown.getFailures()).containsExactly(entry(source1, ex));
 			verify(sink1).stop(pulsarAdmin);
 			verify(function1).stop(pulsarAdmin);
@@ -485,8 +485,8 @@ class PulsarFunctionAdministrationTests {
 		void middleProcessedFunctionFails() {
 			var ex = new PulsarException("BOOM");
 			doThrow(ex).when(sink1).stop(pulsarAdmin);
-			var thrown = catchThrowableOfType(() -> functionAdmin.enforceStopPolicyOnUserDefinedFunctions(),
-					PulsarFunctionException.class);
+			var thrown = catchThrowableOfType(PulsarFunctionException.class,
+					() -> functionAdmin.enforceStopPolicyOnUserDefinedFunctions());
 			assertThat(thrown.getFailures()).containsExactly(entry(sink1, ex));
 			verify(source1).stop(pulsarAdmin);
 			verify(function1).stop(pulsarAdmin);
@@ -496,8 +496,8 @@ class PulsarFunctionAdministrationTests {
 		void lastProcessedFunctionFails() {
 			var ex = new PulsarException("BOOM");
 			doThrow(ex).when(function1).stop(pulsarAdmin);
-			var thrown = catchThrowableOfType(() -> functionAdmin.enforceStopPolicyOnUserDefinedFunctions(),
-					PulsarFunctionException.class);
+			var thrown = catchThrowableOfType(PulsarFunctionException.class,
+					() -> functionAdmin.enforceStopPolicyOnUserDefinedFunctions());
 			assertThat(thrown.getFailures()).containsExactly(entry(function1, ex));
 			verify(source1).stop(pulsarAdmin);
 			verify(sink1).stop(pulsarAdmin);
@@ -511,8 +511,8 @@ class PulsarFunctionAdministrationTests {
 			doThrow(ex1).when(source1).stop(pulsarAdmin);
 			doThrow(ex2).when(sink1).stop(pulsarAdmin);
 			doThrow(ex3).when(function1).stop(pulsarAdmin);
-			var thrown = catchThrowableOfType(() -> functionAdmin.enforceStopPolicyOnUserDefinedFunctions(),
-					PulsarFunctionException.class);
+			var thrown = catchThrowableOfType(PulsarFunctionException.class,
+					() -> functionAdmin.enforceStopPolicyOnUserDefinedFunctions());
 			assertThat(thrown.getFailures()).containsExactly(entry(source1, ex1), entry(sink1, ex2),
 					entry(function1, ex3));
 		}


### PR DESCRIPTION
This fixes some AssertJ deprecations that came along w/ the update to AssertJ `3.73`.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
