### PR TITLE
Remove no longer needed exclusions from pulsar-client-all

### DIFF
--- a/spring-pulsar/spring-pulsar.gradle
+++ b/spring-pulsar/spring-pulsar.gradle
@@ -9,7 +9,6 @@ dependencies {
 	api 'io.micrometer:micrometer-observation'
 	api (libs.pulsar.client.all) {
 		exclude group: 'org.apache.logging.log4j'
-		exclude group: 'com.sun.activation', module: 'javax.activation'
 		exclude group: 'javax.validation', module: 'validation-api'
 		exclude group: 'com.google.protobuf', module: 'protobuf-java'
 	}


### PR DESCRIPTION
The improvements introduced in [this PR](https://github.com/apache/pulsar/pull/23647) include handling `javax.activation` via shading and migrating from javax to jakarta. Given these changes, we should remove some of the now unnecessary exclusions.

Fix #963 