### PR TITLE
Stop using Class as map key for custom mappings

### DIFF
--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultSchemaResolverTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultSchemaResolverTests.java
@@ -79,6 +79,7 @@ class DefaultSchemaResolverTests {
 	@Nested
 	class CustomSchemaMappingsAPI {
 
+		@SuppressWarnings("removal")
 		@Test
 		void noMappingsByDefault() {
 			assertThat(resolver.getCustomSchemaMappings()).asInstanceOf(InstanceOfAssertFactories.MAP).isEmpty();
@@ -88,14 +89,13 @@ class DefaultSchemaResolverTests {
 		void addMappings() {
 			Schema<?> previouslyMappedSchema = resolver.addCustomSchemaMapping(Foo.class, Schema.STRING);
 			assertThat(previouslyMappedSchema).isNull();
-			assertThat(resolver.getCustomSchemaMappings()).asInstanceOf(InstanceOfAssertFactories.MAP)
-				.containsEntry(Foo.class, Schema.STRING);
+			assertThat(resolver.getCustomSchemaMapping(Foo.class)).hasValue(Schema.STRING);
 			previouslyMappedSchema = resolver.addCustomSchemaMapping(Foo.class, Schema.BOOL);
 			assertThat(previouslyMappedSchema).isEqualTo(Schema.STRING);
-			assertThat(resolver.getCustomSchemaMappings()).asInstanceOf(InstanceOfAssertFactories.MAP)
-				.containsEntry(Foo.class, Schema.BOOL);
+			assertThat(resolver.getCustomSchemaMapping(Foo.class)).hasValue(Schema.BOOL);
 		}
 
+		@SuppressWarnings("removal")
 		@Test
 		void removeMappings() {
 			Schema<?> previouslyMappedSchema = resolver.removeCustomMapping(Foo.class);
@@ -423,10 +423,11 @@ class DefaultSchemaResolverTests {
 				.endsWith(JsonMsgType.class.getSimpleName());
 
 			// verify added to custom mappings
-			assertThat(resolver.getCustomSchemaMappings().get(JsonMsgType.class)).isSameAs(resolvedSchema);
+			assertThat(resolver.getCustomSchemaMapping(JsonMsgType.class))
+				.hasValueSatisfying((v) -> assertThat(v).isSameAs(resolvedSchema));
 
 			// verify subsequent calls skip resolution again
-			assertThat(resolver.resolveSchema(JsonMsgType.class, false).orElseThrow()).isSameAs(resolvedSchema);
+			assertThat(resolver.resolveSchema(JsonMsgType.class, false).orElseThrow()).isEqualTo(resolvedSchema);
 			verify(resolver, times(1)).getAnnotatedSchemaType(JsonMsgType.class);
 		}
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultTopicResolverTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultTopicResolverTests.java
@@ -166,7 +166,7 @@ class DefaultTopicResolverTests {
 			assertThat(resolver.resolveTopic(null, Baz.class, () -> defaultTopic).value().orElse(null))
 				.isEqualTo(bazTopic);
 			// verify added to custom mappings
-			assertThat(resolver.getCustomTopicMappings().get(Baz.class)).isEqualTo(bazTopic);
+			assertThat(resolver.getCustomTopicMapping(Baz.class)).hasValue(bazTopic);
 			// verify subsequent calls skip resolution again
 			assertThat(resolver.resolveTopic(null, Baz.class, () -> defaultTopic).value().orElse(null))
 				.isEqualTo(bazTopic);
@@ -242,6 +242,7 @@ class DefaultTopicResolverTests {
 			resolver = new DefaultTopicResolver();
 		}
 
+		@SuppressWarnings("removal")
 		@Test
 		void noMappingsByDefault() {
 			resolver = new DefaultTopicResolver();
@@ -254,14 +255,13 @@ class DefaultTopicResolverTests {
 			String topic2 = "bar-topic";
 			String previouslyMappedTopic = resolver.addCustomTopicMapping(Foo.class, topic1);
 			assertThat(previouslyMappedTopic).isNull();
-			assertThat(resolver.getCustomTopicMappings()).asInstanceOf(InstanceOfAssertFactories.MAP)
-				.containsEntry(Foo.class, topic1);
+			assertThat(resolver.getCustomTopicMapping(Foo.class)).hasValue(topic1);
 			previouslyMappedTopic = resolver.addCustomTopicMapping(Foo.class, topic2);
 			assertThat(previouslyMappedTopic).isEqualTo(topic1);
-			assertThat(resolver.getCustomTopicMappings()).asInstanceOf(InstanceOfAssertFactories.MAP)
-				.containsEntry(Foo.class, topic2);
+			assertThat(resolver.getCustomTopicMapping(Foo.class)).hasValue(topic2);
 		}
 
+		@SuppressWarnings("removal")
 		@Test
 		void removeMappings() {
 			String previouslyMappedTopic = resolver.removeCustomMapping(Foo.class);


### PR DESCRIPTION
This commit updates the DefaultTopicResolver and DefaulSchemaResolver to use String class names rather than Class instances as map keys for their custom mappings.

Resolves #1078

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
