### PR TITLE
Fix getCustomMappings API for resolvers

### DIFF
--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultSchemaResolverTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultSchemaResolverTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.pulsar.core;
 
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -104,6 +105,15 @@ class DefaultSchemaResolverTests {
 			previouslyMappedSchema = resolver.removeCustomMapping(Foo.class);
 			assertThat(previouslyMappedSchema).isEqualTo(Schema.STRING);
 			assertThat(resolver.getCustomSchemaMappings()).asInstanceOf(InstanceOfAssertFactories.MAP).isEmpty();
+		}
+
+		@SuppressWarnings("removal")
+		@Test
+		void getCustomMappingsReturnsMapping() {
+			assertThat(resolver.getCustomSchemaMappings()).asInstanceOf(InstanceOfAssertFactories.MAP).isEmpty();
+			resolver.addCustomSchemaMapping(Foo.class, Schema.STRING);
+			assertThat(resolver.getCustomSchemaMappings()).asInstanceOf(InstanceOfAssertFactories.MAP)
+				.containsExactly(entry(Foo.class, Schema.STRING));
 		}
 
 	}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultTopicResolverTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultTopicResolverTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.pulsar.core;
 
+import static java.util.Map.entry;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.spy;
@@ -270,6 +271,15 @@ class DefaultTopicResolverTests {
 			previouslyMappedTopic = resolver.removeCustomMapping(Foo.class);
 			assertThat(previouslyMappedTopic).isEqualTo(fooTopic);
 			assertThat(resolver.getCustomTopicMappings()).asInstanceOf(InstanceOfAssertFactories.MAP).isEmpty();
+		}
+
+		@SuppressWarnings("removal")
+		@Test
+		void getCustomMappingsReturnsMapping() {
+			assertThat(resolver.getCustomTopicMappings()).asInstanceOf(InstanceOfAssertFactories.MAP).isEmpty();
+			resolver.addCustomTopicMapping(Foo.class, "fooTopic");
+			assertThat(resolver.getCustomTopicMappings()).asInstanceOf(InstanceOfAssertFactories.MAP)
+				.containsExactly(entry(Foo.class, "fooTopic"));
 		}
 
 	}


### PR DESCRIPTION
This fixes the DefaultTopicResolver.getCustomTopicMappings and DefaultSchemaResolver.getCustomSchemaMappings APIs to actually return the mappings and also use ClassUtils.forName instead of Class.forName to safely load the class from string key.
<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
