### PR TITLE
Fix listener TaskExecutor config

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/AbstractPulsarListenerContainerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/AbstractPulsarListenerContainerFactory.java
@@ -115,7 +115,6 @@ public abstract class AbstractPulsarListenerContainerFactory<C extends AbstractP
 
 		endpoint.setupListenerContainer(instance, this.messageConverter);
 		initializeContainer(instance, endpoint);
-		// customizeContainer(instance);
 		return instance;
 	}
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactory.java
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * @author Chris Bono
  * @author Alexander Preuß
  * @author Vedran Pavic
+ * @author Daniel Szabo
  */
 public class ConcurrentPulsarListenerContainerFactory<T>
 		extends AbstractPulsarListenerContainerFactory<ConcurrentPulsarMessageListenerContainer<T>, T> {
@@ -80,6 +81,7 @@ public class ConcurrentPulsarListenerContainerFactory<T>
 		var containerProps = new PulsarContainerProperties();
 
 		// Map factory props (defaults) to the container props
+		containerProps.setConsumerTaskExecutor(factoryProps.getConsumerTaskExecutor());
 		containerProps.setSchemaResolver(factoryProps.getSchemaResolver());
 		containerProps.setTopicResolver(factoryProps.getTopicResolver());
 		containerProps.setSubscriptionType(factoryProps.getSubscriptionType());

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactoryTests.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.listener.PulsarContainerProperties;
 
@@ -138,6 +139,28 @@ class ConcurrentPulsarListenerContainerFactoryTests {
 				.startsWith("org.springframework.Pulsar.PulsarListenerEndpointContainer#");
 			assertThat(container1.getContainerProperties().getSubscriptionName())
 				.isNotEqualTo(container2.getContainerProperties().getSubscriptionName());
+		}
+
+	}
+
+	@Nested
+	class ConsumerTaskExecutor {
+
+		@Test
+		@SuppressWarnings("unchecked")
+		void factoryValueCopiedWhenCreatingContainer() {
+			final var factoryProps = new PulsarContainerProperties();
+			factoryProps.setConsumerTaskExecutor(new SimpleAsyncTaskExecutor());
+			final var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			final var endpoint = mock(PulsarListenerEndpoint.class);
+			// Mockito by default returns 0 for Integer
+			when(endpoint.getConcurrency()).thenReturn(null);
+
+			final var createdContainer = containerFactory.createRegisteredContainer(endpoint);
+
+			final var containerProperties = createdContainer.getContainerProperties();
+			assertThat(containerProperties.getConsumerTaskExecutor()).isEqualTo(factoryProps.getConsumerTaskExecutor());
 		}
 
 	}


### PR DESCRIPTION
Fixes #1103

I noticed there are missing unit tests for the listener container default property setup. I tried creating them, but it seems like a larger piece of work with all the factory / endpoint / default branches.

Should I work on that and create a separate PR for it, or would it not add that much value?
