### PR TITLE
Update to Spring Javaformat / checkstyle (prepare for JSpecify)

### DIFF
--- a/buildSrc/src/main/java/org/springframework/pulsar/gradle/JavaConventionsPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/pulsar/gradle/JavaConventionsPlugin.java
@@ -120,10 +120,12 @@ public class JavaConventionsPlugin implements Plugin<Project> {
 		});
 		project.getPlugins().apply(CheckstylePlugin.class);
 		CheckstyleExtension checkstyle = project.getExtensions().getByType(CheckstyleExtension.class);
-		checkstyle.setToolVersion("10.12.4");
+		checkstyle.setToolVersion("10.25.0");
 		checkstyle.getConfigDirectory().set(project.getRootProject().file("src/checkstyle"));
 		String version = SpringJavaFormatPlugin.class.getPackage().getImplementationVersion();
 		DependencySet checkstyleDependencies = project.getConfigurations().getByName("checkstyle").getDependencies();
+		checkstyleDependencies
+				.add(project.getDependencies().create("com.puppycrawl.tools:checkstyle:" + checkstyle.getToolVersion()));
 		checkstyleDependencies
 				.add(project.getDependencies().create("io.spring.javaformat:spring-javaformat-checkstyle:" + version));
 	}

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/DefaultTenantAndNamespaceTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/DefaultTenantAndNamespaceTests.java
@@ -87,7 +87,7 @@ class DefaultTenantAndNamespaceTests {
 
 	}
 
-	private static class TestVerifyUtils {
+	private static final class TestVerifyUtils {
 
 		static void verifyProduceConsume(CapturedOutput output, int numExpectedMessages,
 				Function<Integer, Object> expectedMessageFactory) {

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/logging/PulsarTemplateLambdaWarnLoggerTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/logging/PulsarTemplateLambdaWarnLoggerTests.java
@@ -148,7 +148,7 @@ class PulsarTemplateLambdaWarnLoggerTests {
 
 	}
 
-	private static class TestUtils {
+	private static final class TestUtils {
 
 		private static void sendRequestsWithCustomizer(String testPrefix, int numberOfSends,
 				PulsarTemplate<String> template) {

--- a/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-app/src/main/java/org/springframework/pulsar/sample/signup/config/AppConfig.java
+++ b/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-app/src/main/java/org/springframework/pulsar/sample/signup/config/AppConfig.java
@@ -34,6 +34,7 @@ import org.springframework.pulsar.function.PulsarSink;
 import org.springframework.pulsar.function.PulsarSource;
 import org.springframework.pulsar.sample.signup.model.SignupGenerator;
 
+@SuppressWarnings("removal")
 @Configuration(proxyBeanMethods = false)
 class AppConfig {
 
@@ -41,6 +42,7 @@ class AppConfig {
 	SignupGenerator signupGenerator() {
 		return new SignupGenerator();
 	}
+
 
 	@Bean
 	Jackson2JsonMessageConverter jackson2JsonMessageConverter() {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactory.java
@@ -54,6 +54,8 @@ public class ConcurrentPulsarListenerContainerFactory<T>
 	/**
 	 * Specify the container concurrency.
 	 * @param concurrency the number of consumers to create.
+	 * @deprecated since 1.2.0 for removal in 2.0.0 in favor of
+	 * {@link PulsarContainerProperties#setConcurrency}
 	 */
 	@Deprecated(since = "1.2.0", forRemoval = true)
 	public void setConcurrency(Integer concurrency) {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/SchemaResolverTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/SchemaResolverTests.java
@@ -103,7 +103,7 @@ class SchemaResolverTests {
 
 	}
 
-	private static class TestSchemaResolver implements SchemaResolver {
+	private static final class TestSchemaResolver implements SchemaResolver {
 
 		private final SchemaResolver delegate = mock(SchemaResolver.class);
 

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -27,12 +27,10 @@
 		<module name="AnnotationUseStyle">
 			<property name="elementStyle" value="compact"/>
 		</module>
-		<module name="MissingOverride"/>
-		<module name="PackageAnnotation"/>
-		<module name="AnnotationLocation">
-			<property name="allowSamelineSingleParameterlessAnnotation"
-					  value="false"/>
-		</module>
+		<module name="MissingOverride" />
+		<module name="MissingDeprecated" />
+		<module name="PackageAnnotation" />
+		<module name="io.spring.javaformat.checkstyle.check.SpringAnnotationLocationCheck" />
 
 		<!-- Block Checks -->
 		<module name="EmptyBlock">
@@ -119,7 +117,7 @@
 		<module name="JavadocMethod">
 		</module>
 		<module name="JavadocVariable">
-			<property name="scope" value="public"/>
+			<property name="accessModifiers" value="public"/>
 		</module>
 		<module name="JavadocStyle">
 			<property name="checkEmptyJavadoc" value="true"/>


### PR DESCRIPTION
This commit updates to Javaformat to 0.0.47 and the Checkstyle tools to 10.25.0.

The `SpringAnnotationLocationCheck` has also been added to the checkstyle rules in order to prepare for the migration to Jspecify for nullability constraints.

Also, various code has been updated to abide by the new format and checkstyle rules in the updated versions.

See #1150

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
