### PR TITLE
Stop shading checker-qual in caffeine cache provider (1.2.x line)

### DIFF
--- a/spring-pulsar-cache-provider-caffeine/spring-pulsar-cache-provider-caffeine.gradle
+++ b/spring-pulsar-cache-provider-caffeine/spring-pulsar-cache-provider-caffeine.gradle
@@ -23,10 +23,9 @@ shadowJar {
 	}
 	relocate 'com.github.benmanes.caffeine', 'org.springframework.pulsar.shade.com.github.benmanes.caffeine'
 	relocate 'com.google', 'org.springframework.pulsar.shade.com.google'
-	relocate 'org.checkerframework', 'org.springframework.pulsar.shade.org.checkerframework'
 	dependencies {
 		exclude(dependency {
-			!['com.github.ben-manes.caffeine', 'org.checkerframework', 'com.google.errorprone'].contains(it.moduleGroup)
+			!['com.github.ben-manes.caffeine', 'com.google.errorprone'].contains(it.moduleGroup)
 		})
 	}
 }


### PR DESCRIPTION
This commit adjusts the shading in the spring-pulsar-cache-provider-caffeine module to not include the `org.checkerframework:checker-qual` in the shaded jar.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
