### PR TITLE
Remove listenerScope field override in annotation processors

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
@@ -109,8 +109,6 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V> extends Abstra
 
 	private final Set<Class<?>> nonAnnotatedClasses = Collections.newSetFromMap(new ConcurrentHashMap<>(64));
 
-	private final ListenerScope listenerScope = new ListenerScope();
-
 	private final AtomicInteger counter = new AtomicInteger();
 
 	private final List<MethodReactivePulsarListenerEndpoint<?>> processedEndpoints = new ArrayList<>();

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
@@ -106,8 +106,6 @@ public class PulsarListenerAnnotationBeanPostProcessor<V> extends AbstractPulsar
 
 	private final Set<Class<?>> nonAnnotatedClasses = Collections.newSetFromMap(new ConcurrentHashMap<>(64));
 
-	private final ListenerScope listenerScope = new ListenerScope();
-
 	private final AtomicInteger counter = new AtomicInteger();
 
 	private final List<MethodPulsarListenerEndpoint<?>> processedEndpoints = new ArrayList<>();


### PR DESCRIPTION
This commit fixes the case where SpEL expressions using the `__listener.` bean ref were failing due to the concrete impls of the `AbstractPulsarAnnotationsBeanPostProcessor` hiding/overriding their parent's `listenerScope` field by removing the `listenerScope` field from the following concrete impls:
- PulsarListenerAnnotationBeanPostProcessor
- ReactivePulsarListenerAnnotationBeanPostProcessor

See #1169

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
