### PR TITLE
Allow `DeadLetterPolicy#deadLetterTopic` to be non-fully-qualified

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarConsumerFactory.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarConsumerFactory.java
@@ -98,6 +98,18 @@ public class DefaultReactivePulsarConsumerFactory<T> implements ReactivePulsarCo
 			var fullyQualifiedTopics = topics.stream().map(this.topicBuilder::getFullyQualifiedNameForTopic).toList();
 			mutableSpec.setTopicNames(fullyQualifiedTopics);
 		}
+		if (mutableSpec.getDeadLetterPolicy() != null) {
+			var dlt = mutableSpec.getDeadLetterPolicy().getDeadLetterTopic();
+			if (dlt != null) {
+				mutableSpec.getDeadLetterPolicy()
+					.setDeadLetterTopic(this.topicBuilder.getFullyQualifiedNameForTopic(dlt));
+			}
+			var rlt = mutableSpec.getDeadLetterPolicy().getRetryLetterTopic();
+			if (rlt != null) {
+				mutableSpec.getDeadLetterPolicy()
+					.setRetryLetterTopic(this.topicBuilder.getFullyQualifiedNameForTopic(rlt));
+			}
+		}
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
@@ -146,6 +146,20 @@ public class DefaultPulsarConsumerFactory<T> implements PulsarConsumerFactory<T>
 			var fullyQualifiedTopics = topics.stream().map(this.topicBuilder::getFullyQualifiedNameForTopic).toList();
 			builderImpl.getConf().setTopicNames(new HashSet<>(fullyQualifiedTopics));
 		}
+		if (builderImpl.getConf().getDeadLetterPolicy() != null) {
+			var dlt = builderImpl.getConf().getDeadLetterPolicy().getDeadLetterTopic();
+			if (dlt != null) {
+				builderImpl.getConf()
+					.getDeadLetterPolicy()
+					.setDeadLetterTopic(this.topicBuilder.getFullyQualifiedNameForTopic(dlt));
+			}
+			var rlt = builderImpl.getConf().getDeadLetterPolicy().getRetryLetterTopic();
+			if (rlt != null) {
+				builderImpl.getConf()
+					.getDeadLetterPolicy()
+					.setRetryLetterTopic(this.topicBuilder.getFullyQualifiedNameForTopic(rlt));
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
I chose `PulsarListenerAnnotationBeanPostProcessor` because I think it's easier to inject `PulsarTopicBuilder` into it, which I think is better than passing it to `MethodPulsarListenerEndpoint` later.

Closes: gh-1241