### PR TITLE
Remove Java 8 requirement from sample function app

### DIFF
--- a/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-function/build.gradle
+++ b/spring-pulsar-sample-apps/sample-pulsar-functions/sample-signup-function/build.gradle
@@ -5,18 +5,17 @@ plugins {
 group = 'org.springframework.pulsar.sample'
 description = 'Sample Signup Pulsar Function'
 
-java {
-	sourceCompatibility = JavaVersion.VERSION_1_8
-	targetCompatibility = JavaVersion.VERSION_1_8
-}
-
-repositories { 
+repositories {
 	mavenCentral()
 }
 
+java {
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
+}
+
 def versionCatalog = extensions.getByType(VersionCatalogsExtension).named("libs")
-// At Pulsar 4.0.6 things break related to jdk8 requirement - hardcoding at 4.0.5 for now
-def pulsarVersion = '4.0.7'
+def pulsarVersion = project.properties['pulsarVersion'] ?: versionCatalog.findVersion("pulsar").orElseThrow().displayName
 
 dependencies {
 	implementation "org.apache.pulsar:pulsar-client-all:${pulsarVersion}"


### PR DESCRIPTION
This removes the previous requirement for the sample-signup-app to target Java 8. It was required due to a now non-existent limitation in the Pulsar functions client.

It also removes the previous requirement for the sample-signup-app to use Pulsar client version `4.0.5`. It was required due to a limmitation in the Pulsar version `4.0.6` which has since been addressed in Pulsar `4.0.6+`. Therefore, the Pulsar version used in now derived from the Gradle platform.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
