### PR TITLE
Check listener transactional property

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ micrometer = "1.16.4"
 micrometer-docs-gen = "1.0.4"
 micrometer-tracing = "1.6.4"
 protobuf = "3.25.9"
-pulsar = "4.1.3"
+pulsar = "4.2.0"
 spring = "7.0.6"
 # tests
 assertj = "3.27.7"

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/app/PulsarContainerWithSsl.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/app/PulsarContainerWithSsl.java
@@ -48,6 +48,9 @@ final class PulsarContainerWithSsl extends PulsarContainer {
 		withStartupTimeout(Duration.ofMinutes(3));
 		withEnv("PF_ENV_DEBUG", "1");
 
+		// Advertise on localhost
+		withEnv("PULSAR_PREFIX_advertisedAddress", "localhost");
+
 		// TLS ports
 		addExposedPorts(BROKER_TLS_PORT, BROKER_HTTP_TLS_PORT);
 		withEnv("PULSAR_PREFIX_brokerServicePortTls", String.valueOf(BROKER_TLS_PORT));

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/app/SamplePulsarApplicationTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/app/SamplePulsarApplicationTests.java
@@ -33,7 +33,8 @@ class SamplePulsarApplicationTests {
 	@SuppressWarnings("unused")
 	@Container
 	@ServiceConnection
-	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage());
+	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage())
+		.withEnv("PULSAR_PREFIX_advertisedAddress", "localhost");
 
 	@Nested
 	class ImperativeAppTests implements SpringBootTestImperativeApp {

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/DefaultTenantAndNamespaceTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/config/DefaultTenantAndNamespaceTests.java
@@ -47,7 +47,8 @@ class DefaultTenantAndNamespaceTests {
 	@SuppressWarnings("unused")
 	@Container
 	@ServiceConnection
-	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage());
+	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage())
+		.withEnv("PULSAR_PREFIX_advertisedAddress", "localhost");
 
 	@Nested
 	@SpringBootTest(classes = ImperativeAppConfig.class,

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/function/PulsarFunctionAdministrationIntegrationTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/function/PulsarFunctionAdministrationIntegrationTests.java
@@ -87,7 +87,8 @@ class PulsarFunctionAdministrationIntegrationTests {
 	private static final String PULSAR_TOPIC = "pft_foo-topic";
 
 	private static final PulsarContainer PULSAR_CONTAINER = new PulsarContainer(
-			PulsarTestContainerSupport.getPulsarImage());
+			PulsarTestContainerSupport.getPulsarImage())
+		.withEnv("PULSAR_PREFIX_advertisedAddress", "localhost");
 
 	private static final RabbitMQContainer RABBITMQ_CONTAINER = new RabbitMQContainer("rabbitmq");
 

--- a/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/logging/PulsarTemplateLambdaWarnLoggerTests.java
+++ b/integration-tests/src/intTest/java/org/springframework/pulsar/inttest/logging/PulsarTemplateLambdaWarnLoggerTests.java
@@ -64,7 +64,8 @@ class PulsarTemplateLambdaWarnLoggerTests {
 	@SuppressWarnings("unused")
 	@Container
 	@ServiceConnection
-	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage());
+	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage())
+		.withEnv("PULSAR_PREFIX_advertisedAddress", "localhost");
 
 	@Nested
 	@SpringBootTest(classes = TestAppConfig.class)

--- a/spring-pulsar-sample-apps/sample-failover-custom-router/compose.yaml
+++ b/spring-pulsar-sample-apps/sample-failover-custom-router/compose.yaml
@@ -4,4 +4,4 @@ services:
     ports:
       - '6650'
       - '8080'
-    command: 'bin/pulsar standalone'
+    command: 'bin/pulsar standalone --advertised-address localhost '

--- a/spring-pulsar-sample-apps/sample-failover-custom-router/compose.yaml
+++ b/spring-pulsar-sample-apps/sample-failover-custom-router/compose.yaml
@@ -1,6 +1,6 @@
 services:
   pulsar:
-    image: 'apachepulsar/pulsar:4.1.3'
+    image: 'apachepulsar/pulsar:4.2.0'
     ports:
       - '6650'
       - '8080'

--- a/spring-pulsar-sample-apps/sample-imperative-produce-consume/compose.yaml
+++ b/spring-pulsar-sample-apps/sample-imperative-produce-consume/compose.yaml
@@ -4,4 +4,4 @@ services:
     ports:
       - '6650'
       - '8080'
-    command: 'bin/pulsar standalone'
+    command: 'bin/pulsar standalone --advertised-address localhost '

--- a/spring-pulsar-sample-apps/sample-imperative-produce-consume/compose.yaml
+++ b/spring-pulsar-sample-apps/sample-imperative-produce-consume/compose.yaml
@@ -1,6 +1,6 @@
 services:
   pulsar:
-    image: 'apachepulsar/pulsar:4.1.3'
+    image: 'apachepulsar/pulsar:4.2.0'
     ports:
       - '6650'
       - '8080'

--- a/spring-pulsar-sample-apps/sample-pulsar-binder/compose.yaml
+++ b/spring-pulsar-sample-apps/sample-pulsar-binder/compose.yaml
@@ -4,4 +4,4 @@ services:
     ports:
       - '6650'
       - '8080'
-    command: 'bin/pulsar standalone'
+    command: 'bin/pulsar standalone --advertised-address localhost '

--- a/spring-pulsar-sample-apps/sample-pulsar-binder/compose.yaml
+++ b/spring-pulsar-sample-apps/sample-pulsar-binder/compose.yaml
@@ -1,6 +1,6 @@
 services:
   pulsar:
-    image: 'apachepulsar/pulsar:4.1.3'
+    image: 'apachepulsar/pulsar:4.2.0'
     ports:
       - '6650'
       - '8080'

--- a/spring-pulsar-sample-apps/sample-pulsar-functions/docker-compose.yml
+++ b/spring-pulsar-sample-apps/sample-pulsar-functions/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3.5'
 
 services:
   pulsar:
-    image: kezhenxu94/pulsar:latest
-    command: bin/pulsar standalone
+    image: 'apachepulsar/pulsar:4.2.0'
+    command: 'bin/pulsar standalone --advertised-address localhost '
     ports:
       - "6650:6650"
       - "8080:8080"

--- a/spring-pulsar-sample-apps/sample-pulsar-functions/download-connectors.sh
+++ b/spring-pulsar-sample-apps/sample-pulsar-functions/download-connectors.sh
@@ -2,6 +2,6 @@
 
 mkdir connectors
 cd connectors
-wget https://archive.apache.org/dist/pulsar/pulsar-4.1.3/connectors/pulsar-io-cassandra-4.1.3.nar
-wget https://archive.apache.org/dist/pulsar/pulsar-4.1.3/connectors/pulsar-io-rabbitmq-4.1.3.nar
+wget https://archive.apache.org/dist/pulsar/pulsar-4.2.0/connectors/pulsar-io-cassandra-4.2.0.nar
+wget https://archive.apache.org/dist/pulsar/pulsar-4.2.0/connectors/pulsar-io-rabbitmq-4.2.0.nar
 cd ..

--- a/spring-pulsar-sample-apps/sample-pulsar-reader/compose.yaml
+++ b/spring-pulsar-sample-apps/sample-pulsar-reader/compose.yaml
@@ -4,4 +4,4 @@ services:
     ports:
       - '6650'
       - '8080'
-    command: 'bin/pulsar standalone'
+    command: 'bin/pulsar standalone --advertised-address localhost '

--- a/spring-pulsar-sample-apps/sample-pulsar-reader/compose.yaml
+++ b/spring-pulsar-sample-apps/sample-pulsar-reader/compose.yaml
@@ -1,6 +1,6 @@
 services:
   pulsar:
-    image: 'apachepulsar/pulsar:4.1.3'
+    image: 'apachepulsar/pulsar:4.2.0'
     ports:
       - '6650'
       - '8080'

--- a/spring-pulsar-test/src/main/java/org/springframework/pulsar/test/support/PulsarTestContainerSupport.java
+++ b/spring-pulsar-test/src/main/java/org/springframework/pulsar/test/support/PulsarTestContainerSupport.java
@@ -30,7 +30,8 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 public interface PulsarTestContainerSupport {
 
-	PulsarContainer PULSAR_CONTAINER = new PulsarContainer(getPulsarImage());
+	PulsarContainer PULSAR_CONTAINER = new PulsarContainer(getPulsarImage()).withEnv("PULSAR_PREFIX_advertisedAddress",
+			"localhost");
 
 	static DockerImageName getPulsarImage() {
 		return DockerImageName.parse("apachepulsar/pulsar:4.2.0");

--- a/spring-pulsar-test/src/main/java/org/springframework/pulsar/test/support/PulsarTestContainerSupport.java
+++ b/spring-pulsar-test/src/main/java/org/springframework/pulsar/test/support/PulsarTestContainerSupport.java
@@ -33,7 +33,7 @@ public interface PulsarTestContainerSupport {
 	PulsarContainer PULSAR_CONTAINER = new PulsarContainer(getPulsarImage());
 
 	static DockerImageName getPulsarImage() {
-		return DockerImageName.parse("apachepulsar/pulsar:4.1.3");
+		return DockerImageName.parse("apachepulsar/pulsar:4.2.0");
 	}
 
 	@BeforeAll

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
@@ -555,7 +555,7 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 		}
 
 		private boolean transactional() {
-			return this.transactionTemplate != null && this.transactionManager != null;
+			return this.transactionTemplate != null && this.transactionManager != null && this.containerProperties.transactions().isEnabled();
 		}
 
 		private void invokeRecordListener(Messages<T> messages, AtomicBoolean inRetryMode) {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
@@ -555,7 +555,9 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 		}
 
 		private boolean transactional() {
-			return this.transactionTemplate != null && this.transactionManager != null && this.containerProperties.transactions().isEnabled();
+			return this.transactionTemplate != null
+					&& this.transactionManager != null
+					&& this.containerProperties.transactions().isEnabled();
 		}
 
 		private void invokeRecordListener(Messages<T> messages, AtomicBoolean inRetryMode) {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateLocalTransactionTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateLocalTransactionTests.java
@@ -57,6 +57,7 @@ import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
 class PulsarTemplateLocalTransactionTests {
 
 	private static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage())
+		.withEnv("PULSAR_PREFIX_advertisedAddress", "localhost")
 		.withTransactions();
 
 	private PulsarClient client;

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTxnTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTxnTests.java
@@ -68,6 +68,7 @@ import org.springframework.pulsar.transaction.PulsarTransactionUtils;
 class DefaultPulsarMessageListenerContainerTxnTests {
 
 	private static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage())
+		.withEnv("PULSAR_PREFIX_advertisedAddress", "localhost")
 		.withTransactions();
 
 	private PulsarClient client;

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/transaction/PulsarTxnTestsBase.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/transaction/PulsarTxnTestsBase.java
@@ -64,6 +64,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 public class PulsarTxnTestsBase {
 
 	static PulsarContainer PULSAR_CONTAINER = new PulsarContainer(PulsarTestContainerSupport.getPulsarImage())
+		.withEnv("PULSAR_PREFIX_advertisedAddress", "localhost")
 		.withTransactions();
 
 	@BeforeAll

--- a/tools/pulsar/docker/standalone/pulsar-start-arm64.sh
+++ b/tools/pulsar/docker/standalone/pulsar-start-arm64.sh
@@ -4,4 +4,4 @@ docker run -it -p 6650:6650 -p 8080:8080 \
   --mount source=pulsardata,target=/pulsar/data \
   --mount source=pulsarconf,target=/pulsar/conf \
   kezhenxu94/pulsar:latest \
-  bin/pulsar standalone
+  bin/pulsar standalone  --advertised-address localhost

--- a/tools/pulsar/docker/standalone/pulsar-start.sh
+++ b/tools/pulsar/docker/standalone/pulsar-start.sh
@@ -3,5 +3,5 @@
 docker run -it -p 6650:6650 -p 8080:8080 \
   --mount source=pulsardata,target=/pulsar/data \
   --mount source=pulsarconf,target=/pulsar/conf \
-  apachepulsar/pulsar:4.1.3 \
+  apachepulsar/pulsar:4.2.0 \
   bin/pulsar standalone

--- a/tools/pulsar/docker/standalone/pulsar-start.sh
+++ b/tools/pulsar/docker/standalone/pulsar-start.sh
@@ -4,4 +4,4 @@ docker run -it -p 6650:6650 -p 8080:8080 \
   --mount source=pulsardata,target=/pulsar/data \
   --mount source=pulsarconf,target=/pulsar/conf \
   apachepulsar/pulsar:4.2.0 \
-  bin/pulsar standalone
+  bin/pulsar standalone --advertised-address localhost


### PR DESCRIPTION
After fix :

```
2026-04-09T10:09:47.490+09:00 DEBUG 42252 --- [spring-pulsar-transaction] [r-client-io-1-3] p.c.i.t.TransactionCoordinatorClientImpl : Transaction meta store assign partition is 1.
2026-04-09T10:10:10.221+09:00 DEBUG 42252 --- [spring-pulsar-transaction] [    Test worker] o.s.p.c.MethodPulsarListenerEndpoint     : Listener w/ id [org.springframework.Pulsar.PulsarListenerEndpointContainer#0] requested no transactions
2026-04-09T10:10:10.620+09:00  INFO 42252 --- [spring-pulsar-transaction] [r-client-io-1-3] o.a.pulsar.client.impl.ConsumerImpl      : [persistent://public/default/test-topic][message] Subscribing to topic on cnx [id: 0x1a215b96, L:/127.0.0.1:62140 - R:localhost/127.0.0.1:37783], consumerId 0
2026-04-09T10:10:10.974+09:00  INFO 42252 --- [spring-pulsar-transaction] [r-client-io-1-5] o.a.pulsar.client.impl.ConsumerImpl      : [persistent://public/default/test-topic][message] Subscribed to topic on localhost/127.0.0.1:37783 -- consumer: 0
2026-04-09T10:10:10.975+09:00 DEBUG 42252 --- [spring-pulsar-transaction] [r-client-io-1-5] o.a.pulsar.client.impl.ConsumerImpl      : [persistent://public/default/test-topic] Sending permit-cmd to broker with available permits = 1000
2026-04-09T10:10:10.975+09:00 DEBUG 42252 --- [spring-pulsar-transaction] [r-client-io-1-5] o.a.pulsar.client.impl.ConsumerImpl      : [persistent://public/default/test-topic] [message] Adding 1000 additional permits
2026-04-09T10:10:10.979+09:00 DEBUG 42252 --- [spring-pulsar-transaction] [r-client-io-1-5] o.a.pulsar.client.impl.ConsumerImpl      : Consumer 0 sent 1000 permits to broker
2026-04-09T10:10:11.888+09:00 DEBUG 42252 --- [spring-pulsar-transaction] [r-client-io-1-5] o.a.pulsar.client.impl.ConsumerImpl      : [persistent://public/default/test-topic][message] Received message: 6:0
2026-04-09T10:10:11.945+09:00  INFO 42252 --- [spring-pulsar-transaction] [ntainer#0-0-C-1] c.g.r.s.listener.MessageListener         : Received message ID 6:0:-1, with txn ID null and txn state null
2026-04-09T10:10:12.094+09:00 DEBUG 42252 --- [spring-pulsar-transaction] [r-client-io-1-5] o.a.pulsar.client.impl.ConsumerImpl      : [persistent://public/default/test-topic][message] Received message: 6:1
2026-04-09T10:10:12.159+09:00  INFO 42252 --- [spring-pulsar-transaction] [ntainer#0-0-C-1] c.g.r.s.listener.MessageListener         : Received message ID 6:1:-1, with txn ID null and txn state null
2026-04-09T10:10:12.263+09:00  INFO 42252 --- [spring-pulsar-transaction] [r-client-io-1-5] o.a.pulsar.client.impl.ConsumerImpl      : [persistent://public/default/test-topic] [message] Closed consumer
```

fixes #1438 