### PR TITLE
Check `@PulsarListener` transactional property

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
@@ -555,7 +555,9 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 		}
 
 		private boolean transactional() {
-			return this.transactionTemplate != null && this.transactionManager != null;
+			return this.transactionTemplate != null
+					&& this.transactionManager != null
+					&& this.containerProperties.transactions().isEnabled();
 		}
 
 		private void invokeRecordListener(Messages<T> messages, AtomicBoolean inRetryMode) {


### PR DESCRIPTION
This adds the `transactional` property of `@PulsarListener` to the check to determine
if this container should execute in a transaction.