### PR TITLE
Propagate startup failure properties to created container

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactory.java
@@ -77,6 +77,10 @@ public class ConcurrentPulsarListenerContainerFactory<T>
 		containerProps.setTopicResolver(factoryProps.getTopicResolver());
 		containerProps.setSubscriptionType(factoryProps.getSubscriptionType());
 		containerProps.setSubscriptionName(factoryProps.getSubscriptionName());
+		// Set the retry template before the policy as setting a non-null template
+		// implicitly switches the policy to RETRY
+		containerProps.setStartupFailureRetryTemplate(factoryProps.getStartupFailureRetryTemplate());
+		containerProps.setStartupFailurePolicy(factoryProps.getStartupFailurePolicy());
 		var factoryTxnProps = factoryProps.transactions();
 		var containerTxnProps = containerProps.transactions();
 		containerTxnProps.setEnabled(factoryTxnProps.isEnabled());

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/config/ConcurrentPulsarListenerContainerFactoryTests.java
@@ -24,6 +24,8 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.listener.PulsarContainerProperties;
@@ -147,6 +149,60 @@ class ConcurrentPulsarListenerContainerFactoryTests {
 			assertThat(container.getContainerProperties())
 				.extracting(PulsarContainerProperties::getConsumerTaskExecutor)
 				.isSameAs(executor);
+		}
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nested
+	class StartupFailurePolicyFrom {
+
+		@Test
+		void factoryPropsUsedWhenSpecified() {
+			var factoryProps = new PulsarContainerProperties();
+			factoryProps.setStartupFailurePolicy(StartupFailurePolicy.CONTINUE);
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
+			when(endpoint.getConcurrency()).thenReturn(1);
+			var createdContainer = containerFactory.createRegisteredContainer(endpoint);
+			assertThat(createdContainer.getContainerProperties().getStartupFailurePolicy())
+				.isEqualTo(StartupFailurePolicy.CONTINUE);
+		}
+
+		@Test
+		void defaultUsedWhenNotSetOnFactoryProps() {
+			var factoryProps = new PulsarContainerProperties();
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
+			when(endpoint.getConcurrency()).thenReturn(1);
+			var createdContainer = containerFactory.createRegisteredContainer(endpoint);
+			assertThat(createdContainer.getContainerProperties().getStartupFailurePolicy())
+				.isEqualTo(StartupFailurePolicy.STOP);
+		}
+
+	}
+
+	@SuppressWarnings("unchecked")
+	@Nested
+	class StartupFailureRetryTemplateFrom {
+
+		@Test
+		void factoryPropsUsedWhenSpecified() {
+			var factoryProps = new PulsarContainerProperties();
+			var retryTemplate = new RetryTemplate(RetryPolicy.builder().maxRetries(3).build());
+			factoryProps.setStartupFailureRetryTemplate(retryTemplate);
+			var containerFactory = new ConcurrentPulsarListenerContainerFactory<String>(
+					mock(PulsarConsumerFactory.class), factoryProps);
+			var endpoint = mock(PulsarListenerEndpoint.class);
+			when(endpoint.getConcurrency()).thenReturn(1);
+			var createdContainer = containerFactory.createRegisteredContainer(endpoint);
+			assertThat(createdContainer.getContainerProperties().getStartupFailureRetryTemplate())
+				.isSameAs(retryTemplate);
+			// Setting the retry template implicitly switches the policy to RETRY
+			assertThat(createdContainer.getContainerProperties().getStartupFailurePolicy())
+				.isEqualTo(StartupFailurePolicy.RETRY);
 		}
 
 	}


### PR DESCRIPTION
Fixes #1505

## Problem

`ConcurrentPulsarListenerContainerFactory#createContainerInstance` creates a fresh `PulsarContainerProperties` for every container and copies only a curated subset of the factory's container properties onto it (consumer task executor, schema/topic resolvers, subscription type/name, transactions). The **startup failure policy** and **startup failure retry template** are not among them.

As a result, when a user configures `StartupFailurePolicy.RETRY` and/or a custom `startupFailureRetryTemplate` on the factory's container properties — e.g. via a `PulsarContainerFactoryCustomizer`, which is the documented way to opt into startup retries — those settings are silently dropped and the created container keeps the default `STOP` policy (`Configured to stop on startup failures - exiting`).

## Fix

Copy the startup failure retry template and policy from the factory props to the container props in `createContainerInstance`. The retry template is set **before** the policy because `PulsarContainerProperties#setStartupFailureRetryTemplate` implicitly switches the policy to `RETRY` when given a non-null template; the policy is then set explicitly to mirror the factory exactly.

```java
containerProps.setStartupFailureRetryTemplate(factoryProps.getStartupFailureRetryTemplate());
containerProps.setStartupFailurePolicy(factoryProps.getStartupFailurePolicy());
```

## Tests

Added unit tests to `ConcurrentPulsarListenerContainerFactoryTests`:
- `StartupFailurePolicyFrom` — factory's policy is propagated to the created container, and the default (`STOP`) is used when unset.
- `StartupFailureRetryTemplateFrom` — factory's retry template is propagated (and the policy is switched to `RETRY` accordingly).

## Verification done

- `./gradlew :spring-pulsar:test --tests "*ConcurrentPulsarListenerContainerFactoryTests"` — BUILD SUCCESSFUL (new tests pass; compiled with `-Werror` and the project's nullability/errorprone checks).
- `./gradlew :spring-pulsar:checkFormat :spring-pulsar:checkstyleMain :spring-pulsar:checkstyleTest` — BUILD SUCCESSFUL.
- Change is limited to the two files above (a stray pre-existing formatting diff the `format` task surfaced in an unrelated class was reverted).

Note: this PR addresses the startup-failure properties called out by the reproducer; if maintainers prefer, the same propagation block could later be reviewed for any other factory-level properties not yet copied.