### PR TITLE
Fix thread safety of thread-bound transactions in PulsarTemplate

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
@@ -19,9 +19,7 @@ package org.springframework.pulsar.core;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -75,7 +73,7 @@ public class PulsarTemplate<T>
 
 	private @Nullable final List<ProducerBuilderCustomizer<T>> interceptorsCustomizers;
 
-	private final Map<Thread, Transaction> threadBoundTransactions = new HashMap<>();
+	private final ThreadLocal<Transaction> threadBoundTransactions = new ThreadLocal<>();
 
 	private final boolean isProducerFactoryCaching;
 
@@ -197,9 +195,9 @@ public class PulsarTemplate<T>
 			return;
 		}
 		this.observationRegistry = this.applicationContext.getBeanProvider(ObservationRegistry.class)
-			.getIfUnique(() -> this.observationRegistry);
+				.getIfUnique(() -> this.observationRegistry);
 		this.observationConvention = this.applicationContext.getBeanProvider(PulsarTemplateObservationConvention.class)
-			.getIfUnique(() -> this.observationConvention);
+				.getIfUnique(() -> this.observationConvention);
 	}
 
 	@Override
@@ -260,7 +258,7 @@ public class PulsarTemplate<T>
 		try {
 			return doSendAsync(topic, message, schema, encryptionKeys, typedMessageBuilderCustomizer,
 					producerCustomizer)
-				.get();
+					.get();
 		}
 		catch (PulsarException ex) {
 			throw ex;
@@ -341,7 +339,7 @@ public class PulsarTemplate<T>
 			this.logger.trace(() -> "No txn found but allowNonTransactional is true - returning null");
 			return null;
 		}
-		Transaction txn = this.threadBoundTransactions.get(Thread.currentThread());
+		Transaction txn = this.threadBoundTransactions.get();
 		if (txn != null) {
 			this.logger.trace(() -> "Found local template txn [%s]".formatted(txn));
 			return txn;
@@ -363,7 +361,7 @@ public class PulsarTemplate<T>
 		if (!this.transactions().isEnabled()) {
 			return false;
 		}
-		return this.threadBoundTransactions.get(Thread.currentThread()) != null
+		return this.threadBoundTransactions.get() != null
 				|| PulsarTransactionUtils.inTransaction(this.producerFactory.getPulsarClient());
 	}
 
@@ -400,11 +398,10 @@ public class PulsarTemplate<T>
 	@Nullable public <R> R executeInTransaction(TemplateCallback<T, R> callback) {
 		Assert.notNull(callback, "callback must not be null");
 		Assert.state(this.transactions().isEnabled(), "This template does not support transactions");
-		var currentThread = Thread.currentThread();
-		var txn = this.threadBoundTransactions.get(currentThread);
+		var txn = this.threadBoundTransactions.get();
 		Assert.state(txn == null, "Nested calls to 'executeInTransaction' are not allowed");
 		txn = newPulsarTransaction();
-		this.threadBoundTransactions.put(currentThread, txn);
+		this.threadBoundTransactions.set(txn);
 		try {
 			R result = callback.doWithTemplate(this);
 			txn.commit().get();
@@ -417,7 +414,7 @@ public class PulsarTemplate<T>
 			throw PulsarException.unwrap(ex);
 		}
 		finally {
-			this.threadBoundTransactions.remove(currentThread);
+			this.threadBoundTransactions.remove();
 		}
 	}
 


### PR DESCRIPTION
PulsarTemplate stored per-thread transactions in a HashMap keyed by Thread. HashMap is not thread-safe, so concurrent use of a shared PulsarTemplate instance could lose transaction bindings. 

Replace with ThreadLocal to correctly scope transaction state per thread without shared mutable map access.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
